### PR TITLE
ci: Workflow to add issues to project automatically

### DIFF
--- a/.github/workflows/add-issue-to-project.yaml
+++ b/.github/workflows/add-issue-to-project.yaml
@@ -1,0 +1,20 @@
+name: Add Issues to Project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/sudlab/projects/1
+          github-token: ${{ secrets.GH_ISSUE_TO_PROJECT }}
+          labeled: admin, blocked, bug, ci, documentation, duplicate, enhancement, epic, good first issue, help wanted, invalid, packaging, question, repository, tests, wontfix
+          label-operator: OR


### PR DESCRIPTION
Adds a workflow using the [actions/add-to-project](https://github.com/actions/add-to-project) action to automatically add issues created within the `SLAMSeq` repository to the [Project Board](https://github.com/orgs/sudlab/projects/1/).