### PR TITLE
package: Initial dependencies added to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,12 @@ keywords = [
   "slamseq",
 ]
 dependencies = [
-  # To come from Conda environment
+  "cgat",
+  "heapq",
+  "matplotlib",
+  "pandas",
+  "pysam",
+  "ruffus",
 ]
 
 


### PR DESCRIPTION
I've looked through the imports in the package itself and the list seems considerably smaller than those from the Conda
environment. This isn't surprising as there is always tons of dependencies that get pulled in.

I searched for import in the existing code and found the unique ones...

```bash
❱ grep -R "import " | awk -F':' '{ print $3 }' | sort | uniq
from cgatcore import pipeline as P
from collections import Counter
from collections import defaultdict
from heapq import merge
from matplotlib import pyplot as plt
from ruffus import *
from statistics import mean
from statistics import median
import cgatcore.experiment as E
import cgatcore.iotools as iotools
import cgatcore.iotools as IOTools
import cgat.GTF as GTF
import cgat.GTF as GTF
import csv
import fnmatch
import glob
import gzip
import io
import os
import pandas as pd
import pysam as pysam
import re
import sqlite3
import sys
```

Many are core libraries but I think I've narrowed down external dependencies to the changes in this commit. I'm sure
I'll find out once I start migrating code if there is anything missing!