### PR TITLE
build: minimal set of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,16 +36,15 @@ keywords = [
   "slamseq",
 ]
 dependencies = [
-  #"cgatcore",
-  #"cgat-apps@git+https://github.com/cgat-developers/cgat-apps",
-  #"cgat-flow@git+https://github.com/cgat-developers/cgat-flow",
-  #"cgat-report",
-  #"heapq",
+  "apsw",
+  "cgatcore",
+  "gevent",
   "matplotlib",
   "numpy",
   "pandas",
   "pysam",
   "ruffus",
+  "sqlalchemy",
 ]
 
 


### PR DESCRIPTION
Closes #33

These packages allow running the code on the minimal reproducible example that @jjriley1 is developing on
[jjriley1/slam_3UIs:jjriley1/1-tidy-up](https://github.com/jjriley1/slam_3UIs/tree/jjriley1/1-tidy-up).

Installing in a clean virtual environment the script at least runs against commit
`0d00ec98253919a3cf5a4b34e5e6bde771acfb1e` (and `fb93e864390e2a3517ffb7ee2bed5ab2cc923a9c`) although currently because
of hard coded files in `pipeline_slam_3UIs/pipeline.yaml` no processing is undertaken with the sample files that have
been provided.

I expect the dependencies to grow as we add more functionality and have deliberately left `pandas`, `numpy` and
`matplotlib` as dependencies as they will be used to do the legwork that the various R scripts currently do.