### PR TITLE
ci: Add workflow for testing action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,53 @@
+name: Tests (pytest)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    paths:
+      - "**.csv"
+      - "**.npy"
+      - "**.out"
+      - "**.pkl"
+      - "**.png"
+      - "**.py"
+      - "**.toml"
+      - "**.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip and install test dependencies
+        run: |
+          pip install --upgrade virtualenv
+          pip install --upgrade pip setuptools
+          virtualenv --upgrade-embed-wheels
+          pip install -e .[tests]
+      - name: Test with pytest
+        run: |
+          pytest --cov=isoslam --cov-report=xml --mpl -x
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 5


### PR DESCRIPTION
Closes #10

- Adds a workflow to run tests on GitHub Actions Continuous Integration.
- It only runs `pull_request` for certain events and even more specifically on changes to specific files (see the `paths` list under `pull_request`).
- Includes [tmate](https://github.com/marketplace/actions/debugging-with-tmate) for when tests fail so its possible to SSH into the runner and have a poke around and work out what is wrong.
- At the same time I've linked the `sudlab/IsoSLAM` repository to [codecov.io](https://codecov.io) so that the tests, which generate code coverage reports (in XML) are uploaded and available for analysis automatically. Required adding a Secret Token from Codecov to the repository.

May be tweaked in future but this is a good starting point.

NB - Currently there aren't any tests, so no report is generated to upload and so the tests fail!