### PR TITLE
ci(dependabot): Adds config to update custom GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #48

Addresses [GH200](https://learn.scientific-python.org/development/guides/gha-basic/#GH200)

**NB** Will also enable dependabot under _Settings > Security_