### PR TITLE
ci(pre-commit): Updates prettier repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,8 +58,8 @@ repos:
     hooks:
       - id: codespell
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
 


### PR DESCRIPTION
Closes #51

Addresses [PC180: Uses a markdown formatter](https://learn.scientific-python.org/development/guides/style#PC180)

Required updating repository and version.