### PR TITLE
package: Removes target-version from ruff; updates black target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ omit = [
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py39']
 exclude = '''
 
 (
@@ -171,7 +171,6 @@ exclude = [
 ]
 # per-file-ignores = []
 line-length = 120
-target-version = "py310"
 lint.select = [
   "A", # flake8-builtins
   "B", # flake8-bugbear


### PR DESCRIPTION
Closes #53

As per [RF002: Target version must be set](https://learn.scientific-python.org/development/guides/style#RF002) removes `target-version` from `ruff` configuration.