### PR TITLE
ci(pre-commit): Adds pygrep repo to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,16 @@ repos:
     hooks:
       - id: numpydoc-validation
 
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: python-no-eval
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+      - id: python-check-mock-methods
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
Closes #50

[PC170 : Uses PyGrep hooks (only needed if rST
present)](https://learn.scientific-python.org/development/guides/style#PC170)

Enables the [pygrep](https://github.com/pre-commit/pygrep-hooks) not just for restructured text but also some other Python hooks it enables.