### PR TITLE
style: Adds mypy configuration and pre-commit repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,14 @@ repos:
       - id: python-check-blanket-noqa
       - id: python-check-blanket-type-ignore
       - id: python-check-mock-methods
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        files: isoslam
+        args: ["--ignore-without-code", "--redundant-expr", "--truthy-bool"]
+
   - repo: local
     hooks:
       - id: pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ docs = [
 dev = [
   "black",
   "ipython",
+  "mypy",
   "pre-commit",
   "pylint",
   "pyupgrade",
@@ -255,3 +256,17 @@ override_SS05 = [  # override SS05 to allow docstrings starting with these words
     "^Assess ",
     "^Access ",
 ]
+
+[tool.mypy]
+files = [
+  "isoslam",
+  "tests"
+]
+python_version = "3.9"
+strict = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = [ "numpy.*", ]
+ignore_missing_imports = true


### PR DESCRIPTION
Closes #49
Closes #52

- [MY100: Uses MyPy (pyproject config)](https://learn.scientific-python.org/development/guides/style#MY100)
- [PC140: Uses a type checker](https://learn.scientific-python.org/development/guides/style#PC140)

Adds configuration of [mypy](https://mypy.readthedocs.io/) to [`pyproject.toml`](https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file) and the related `pre-commit` hook.

May need tweaking.