### PR TITLE
ci: validate-pyproject repo and hook added

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,12 @@ repos:
         files: isoslam
         args: ["--ignore-without-code", "--redundant-expr", "--truthy-bool"]
 
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.23
+    hooks:
+      - id: validate-pyproject
+        additional_dependencies: ["validate-pyproject-schema-store[all]"]
+
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
Closes #54

[Validate Project](https://learn.scientific-python.org/development/guides/style/#schema-validation)

**NB** It appears that currently there is no schema to validate `tool.ruff.lint` so that check fails (locally and in `pre-commit.ci`)