### PR TITLE
ci: disabling pyproject validation for the time being

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,11 +91,14 @@ repos:
         files: isoslam
         args: []
 
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.23
-    hooks:
-      - id: validate-pyproject
-        additional_dependencies: ["validate-pyproject-schema-store[all]"]
+  # @ns-rse (2024-11-27) Currently fails due to `fastjsonschema` not covering `tool.ruff.lint` see
+  # https://github.com/abravalheri/validate-pyproject/issues/180
+  # Disabling for now
+  # - repo: https://github.com/abravalheri/validate-pyproject
+  #   rev: v0.23
+  #   hooks:
+  #     - id: validate-pyproject
+  #       additional_dependencies: ["validate-pyproject-schema-store[all]"]
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,18 +179,16 @@ line-length = 120
 lint.select = [
   "A", # flake8-builtins
   "B", # flake8-bugbear
-  "C", #
   "D", # pydocstyle
   "E", # pycodestyle error
-  "F",
+  "F", # pyflakes
   "I", # isort
   "NPY", # numpy
   "PT", # flake8-pytest-style
   "PTH", # flake8-use-pathlib
-  "R",
+  "R", # refactor (pylint)
   "S", #flake8-bandit
   "W", # pycodestyle warning
-  "U",
   "UP", # pyupgrade
 ]
 lint.ignore = [
@@ -203,19 +201,17 @@ lint.ignore = [
 lint.fixable = [
   "A", # flake8-builtins
   "B", # flake8-bugbear
-  "C", #
   "D", # pydocstyle
   "E", # pycodestyle error
-  "F",
+  "F", # pyflakes
   "I", # isort
   "NPY", # numpy
   "PT", # flake8-pytest-style
   "PTH", # flake8-use-pathlib
-  "R",
+  "R", # refactor (pylint)
   "S", #flake8-bandit
   "W", # pycodestyle warning
-  "U",
-  "UP", # pyupgrade
+ "UP", # pyupgrade
 ]
 lint.unfixable = []
 


### PR DESCRIPTION
The JSON schema against which the `tools.ruff.lint` section is validated doesn't appear to exist yet and throws
errors. I'm not the only person to have encountered this problem see
[here](https://github.com/abravalheri/validate-pyproject/issues/180).

For now I'm disabling the check so that `pre-commit` passes. Will reinstate once fixed.