### PR TITLE
ci: Use --no-build-isolation to instal cgat

### DIFF
--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -24,7 +24,13 @@ jobs:
           python-version: 3.11
       - name: Installing the Documentation requirements
         run: |
-          pip3 install .[docs]
+          # Install build dependencies for now (see
+          # https://github.com/cgat-developers/cgat-apps/issues/134#issuecomment-2503431974)
+          pip install numpy
+          pip install Cython
+          pip install pysam
+          pip install wheel
+          pip3 install --no-build-isolation .[docs]
       - name: Running Sphinx to gh-pages Action
         # Uncomment if only tagged releases are to have documentation built
         # if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -30,6 +30,7 @@ jobs:
           pip install Cython
           pip install pysam
           pip install wheel
+          pip install --no-build-isolation git+https://github.com/cgat-developers/cgat-apps@v0.7.4
           pip3 install --no-build-isolation .[docs]
       - name: Running Sphinx to gh-pages Action
         # Uncomment if only tagged releases are to have documentation built

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -30,7 +30,7 @@ jobs:
           pip install Cython
           pip install pysam
           pip install wheel
-          pip install --no-build-isolation git+https://github.com/cgat-developers/cgat-apps@v0.7.4
+          pip install --no-build-isolation git+https://github.com/cgat-developers/cgat-apps@AC-modifybuild
           pip3 install --no-build-isolation .[docs]
       - name: Running Sphinx to gh-pages Action
         # Uncomment if only tagged releases are to have documentation built

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
           pip install pysam
           pip install wheel
           pip install --no-build-isolation cgatcore
-          pip install --no-build-isolation git+https://github.com/cgat-developers/cgat-apps@v0.7.4
+          pip install --no-build-isolation git+https://github.com/cgat-developers/cgat-apps@AC-modifybuild
           pip install --no-build-isolation -e .[tests]
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"] # "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,10 +40,14 @@ jobs:
           pip install --upgrade virtualenv
           pip install --upgrade pip setuptools
           virtualenv --upgrade-embed-wheels
+          # Install build dependencies for now (see
+          # https://github.com/cgat-developers/cgat-apps/issues/134#issuecomment-2503431974)
           pip install numpy
-          pip show numpy
-          pip install cgatcore
-          pip install cgat
+          pip install Cython
+          pip install pysam
+          pip install wheel
+          pip install --no-build-isolation cgatcore
+          pip install --no-build-isolation cgat
           pip install -e .[tests]
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,8 +47,8 @@ jobs:
           pip install pysam
           pip install wheel
           pip install --no-build-isolation cgatcore
-          pip install --no-build-isolation cgat
-          pip install -e .[tests]
+          pip install --no-build-isolation git+https://github.com/cgat-developers/cgat-apps@v0.7.4
+          pip install --no-build-isolation -e .[tests]
       - name: Test with pytest
         run: |
           pytest --cov=isoslam --cov-report=xml --mpl -x


### PR DESCRIPTION
As [suggested](https://github.com/cgat-developers/cgat-apps/issues/134#issuecomment-2497400890) attempting to install
dependencies (and in one instance `IsoSLAM` itself) with the `--no-build-isolation` flag in the hope that NumPy is
correctly detected by `cgat` when it is built and installed.