### PR TITLE
Add io and utility modules with tests and default config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: rst-inline-touching-normal
       - id: python-no-eval
       - id: python-check-blanket-noqa
-      - id: python-check-blanket-type-ignore
+      # - id: python-check-blanket-type-ignore
       - id: python-check-mock-methods
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/isoslam/default_config.yaml
+++ b/isoslam/default_config.yaml
@@ -1,0 +1,9 @@
+# Default configuration file for running IsoSlam
+log_level: "warning"
+output_dir: output
+bam_file: data/bam/.bam
+gtf_file: data/gtf/
+bed_file: data/bed/
+vcf_file: data/vcf/
+summary: false
+plot: false

--- a/isoslam/io.py
+++ b/isoslam/io.py
@@ -1,0 +1,177 @@
+"""Module for reading files."""
+
+import argparse
+from datetime import datetime
+from importlib import resources
+from pathlib import Path
+
+# from cgatcore import iotools
+from loguru import logger
+
+# import pysam
+from ruamel.yaml import YAML, YAMLError
+
+CONFIG_DOCUMENTATION_REFERENCE = """# For more information on configuration and how to use it see:
+# https://sudlab.github.io/IsoSLAM\n"""
+
+
+def _get_date_time() -> str:
+    """
+    Get a date and time for adding to generated files or logging.
+
+    Returns
+    -------
+    str
+        A string of the current date and time, formatted appropriately.
+    """
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _str_to_path(path: str | Path) -> Path:
+    """
+    Ensure path is a Path object.
+
+    Returns the current directory of passed './'.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to be converted.
+
+    Returns
+    -------
+    Path
+        Pathlib object of supplied path.
+    """
+    return Path().cwd() if path == "./" else Path(path).expanduser()
+
+
+def _path_to_str(config: dict) -> dict:  # type: ignore[type-arg]
+    """
+    Recursively traverse a dictionary and convert any Path() objects to strings for writing to YAML.
+
+    Parameters
+    ----------
+    config : dict
+        Dictionary to be converted.
+
+    Returns
+    -------
+    Dict:
+        The same dictionary with any Path() objects converted to string.
+    """
+    for key, value in config.items():
+        if isinstance(value, dict):
+            _path_to_str(value)
+        elif isinstance(value, Path):
+            config[key] = str(value)
+    return config
+
+
+def read_yaml(filename: str | Path) -> dict | None:  # type: ignore[type-arg]
+    """
+    Read a YAML file.
+
+    Parameters
+    ----------
+    filename : Union[str, Path]
+        YAML file to read.
+
+    Returns
+    -------
+    Dict
+        Dictionary of the file.
+    """
+    with Path(filename).open(encoding="utf-8") as f:
+        try:
+            yaml_file = YAML(typ="safe")
+            return yaml_file.load(f)  # type: ignore[no-any-return]
+        except YAMLError as exception:
+            logger.error(exception)
+            return {}
+
+
+def write_yaml(
+    config: dict,  # type: ignore[type-arg]
+    output_dir: str | Path,
+    config_file: str = "config.yaml",
+    header_message: str | None = None,
+) -> None:
+    """
+    Write a configuration (stored as a dictionary) to a YAML file.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary.
+    output_dir : Union[str, Path]
+        Path to save the dictionary to as a YAML file (it will be called 'config.yaml').
+    config_file : str
+        Filename to write to.
+    header_message : str
+        String to write to the header message of the YAML file.
+    """
+    output_config = Path(output_dir) / config_file
+    # Revert PosixPath items to string
+    config = _path_to_str(config)
+
+    if header_message:
+        header = f"# {header_message} : {_get_date_time()}\n" + CONFIG_DOCUMENTATION_REFERENCE
+    else:
+        header = f"# Configuration from IsoSLAM run completed : {_get_date_time()}\n" + CONFIG_DOCUMENTATION_REFERENCE
+    output_config.write_text(header, encoding="utf-8")
+
+    yaml = YAML(typ="safe")
+    with output_config.open("a", encoding="utf-8") as f:
+        try:
+            yaml.dump(config, f)
+        except YAMLError as exception:
+            logger.error(exception)
+
+
+def create_config(args: argparse.Namespace | None = None) -> None:
+    """
+    Write the default configuration file to disk.
+
+    Parameters
+    ----------
+    args : argparse.Namespace | None
+        Optional arguments to parse.
+    """
+    filename = "config" if args.filename is None else args.filename  # type: ignore [union-attr]
+    output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)  # type: ignore [union-attr]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config_path = resources.files(__package__) / "default_config.yaml"
+    config = config_path.read_text()
+
+    if ".yaml" not in str(filename) and ".yml" not in str(filename):
+        create_config_path = output_dir / f"{filename}.yaml"
+    else:
+        create_config_path = output_dir / filename
+
+    with create_config_path.open("w", encoding="utf-8") as f:
+        f.write(f"# Config file generated {_get_date_time()}\n")
+        f.write(f"{CONFIG_DOCUMENTATION_REFERENCE}")
+        f.write(config)
+    logger.info(f"A sample configuration file has been written to : {str(create_config_path)}")
+    logger.info(CONFIG_DOCUMENTATION_REFERENCE)
+
+
+def load_bam() -> None:
+    """Load '.bam' file."""
+    return
+
+
+def load_bed() -> None:
+    """Load '.bed' file."""
+    return
+
+
+def load_gtf() -> None:
+    """Load '.bed' file."""
+    return
+
+
+def load_vcf() -> None:
+    """Load '.vcf' file."""
+    return

--- a/isoslam/processing.py
+++ b/isoslam/processing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 # from isoslam import __version__
+from isoslam import io
 
 
 def create_parser() -> arg.ArgumentParser:
@@ -110,7 +111,7 @@ def create_parser() -> arg.ArgumentParser:
         default="./",
         help="Path to where the YAML file should be saved (default './' the current directory).",
     )
-    # create_config_parser.set_defaults(func=create_config)
+    create_config_parser.set_defaults(func=io.create_config)
 
     # Additional parsers for future functionality
     # summarize_counts_parser = subparsers.add_parser(
@@ -128,7 +129,7 @@ def create_parser() -> arg.ArgumentParser:
     return parser
 
 
-def process(args: arg.Namespace | None) -> None:
+def process(args: arg.Namespace | None) -> None:  # pylint: disable=unused-argument
     """
     Process a set of files.
 
@@ -142,6 +143,7 @@ def process(args: arg.Namespace | None) -> None:
     None
         Function does not return anything.
     """
+    # config = io.read_yaml() if args.config is None else io.read_yaml(args.config) # type: ignore[call-arg,union-attr]
     return
 
 
@@ -168,7 +170,6 @@ def entry_point(manually_provided_args: list[Any] | None = None, testing: bool =
     args = parser.parse_args() if manually_provided_args is None else parser.parse_args(manually_provided_args)
 
     # If no module has been specified print help and exit
-    print(f"{args.program=}")
     if not args.program:
         parser.print_help()
         sys.exit()

--- a/isoslam/utils.py
+++ b/isoslam/utils.py
@@ -1,0 +1,41 @@
+"""Utilities and helper functionsfor IsoSLAM."""
+
+from argparse import Namespace
+
+from loguru import logger
+
+from isoslam import io
+
+
+def update_config(config: dict, args: dict | Namespace) -> dict:  # type: ignore[type-arg]
+    """
+    Update the configuration with any arguments.
+
+    Parameters
+    ----------
+    config : dict
+        Dictionary of configuration (typically read from YAML file specified with '-c/--config <filename>').
+    args : Namespace
+        Command line arguments.
+
+    Returns
+    -------
+    dict
+        Dictionary updated with command arguments.
+    """
+    args = vars(args) if isinstance(args, Namespace) else args
+
+    config_keys = config.keys()
+    for arg_key, arg_value in args.items():
+        if isinstance(arg_value, dict):
+            update_config(config, arg_value)
+        else:
+            if arg_key in config_keys and arg_value is not None:
+                original_value = config[arg_key]
+                config[arg_key] = arg_value
+                logger.debug(f"Updated config config[{arg_key}] : {original_value} > {arg_value} ")
+    if "base_dir" in config.keys():
+        config["base_dir"] = io._str_to_path(config["base_dir"])  # pylint: disable=protected-access
+    if "output_dir" in config.keys():
+        config["output_dir"] = io._str_to_path(config["output_dir"])  # pylint: disable=protected-access
+    return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,15 @@ keywords = [
 ]
 dependencies = [
   "apsw",
-  "cgat",
-  "cgatcore",
+  # "cgat",
+  # "cgatcore",
   "gevent",
   "loguru",
   "matplotlib",
   "numpy",
   "pandas",
   "pysam",
+  "ruamel.yaml",
   # "ruffus",
   "sqlalchemy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ exclude = [
 ]
 
 [[tool.mypy.overrides]]
-module = [ "numpy.*", ]
+module = [ "numpy.*", "loguru", "ruamel.yaml"]
 ignore_missing_imports = true
 
 [project.scripts]

--- a/tests/resources/test.yaml
+++ b/tests/resources/test.yaml
@@ -1,0 +1,12 @@
+this: is
+a: test
+yaml: file
+int: 123
+float: 3.1415
+logical: true
+nested:
+  something: else
+a_list:
+  - 1
+  - 2
+  - 3

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,142 @@
+"""Test the io.py module."""
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from isoslam import io
+
+BASE_DIR = Path.cwd()
+RESOURCES = BASE_DIR / "tests" / "resources"
+
+
+CONFIG = {
+    "this": "is",
+    "a": "test",
+    "yaml": "file",
+    "int": 123,
+    "float": 3.1415,
+    "logical": True,
+    "nested": {"something": "else"},
+    "a_list": [1, 2, 3],
+}
+
+
+def test_get_date_time() -> None:
+    """Test the fetching of a formatted date and time string."""
+    assert datetime.strptime(io._get_date_time(), "%Y-%m-%d %H:%M:%S")
+
+
+def test_str_to_path(tmp_path: Path) -> None:
+    """Test string objects are converted to Path objects."""
+    test_dir = str(tmp_path)
+    converted_path = io._str_to_path(test_dir)
+
+    assert isinstance(converted_path, Path)
+    assert tmp_path == converted_path
+
+
+def test_path_to_str(tmp_path: Path) -> None:
+    """Test that Path objects are converted to strings."""
+    CONFIG_PATH = {
+        "this": "is",
+        "a": "test",
+        "with": tmp_path,
+        "and": {"nested": tmp_path / "nested"},
+    }
+    CONFIG_STR = io._path_to_str(CONFIG_PATH)
+
+    assert isinstance(CONFIG_STR, dict)
+    assert isinstance(CONFIG_STR["with"], str)
+    assert CONFIG_STR["with"] == str(tmp_path)
+    assert isinstance(CONFIG_STR["and"]["nested"], str)
+    assert CONFIG_STR["and"]["nested"] == str(tmp_path / "nested")
+
+
+def test_read_yaml() -> None:
+    """Test reading of YAML file."""
+    sample_config = io.read_yaml(RESOURCES / "test.yaml")
+
+    assert sample_config == CONFIG
+
+
+def test_create_config(tmp_path: Path) -> None:
+    """Test creation of configuration file from default."""
+
+
+@pytest.mark.parametrize(
+    ("filename", "config", "expected_filename"),
+    [
+        ("test_config_with_comments.yaml", None, "test_config_with_comments.yaml"),
+        ("test_config_with_comments", None, "test_config_with_comments.yaml"),
+        (None, "default", "config.yaml"),
+        (None, None, "config.yaml"),
+    ],
+)
+def test_write_config_with_comments(tmp_path: Path, filename: str, config: str, expected_filename: str) -> None:
+    """Test writing of config file with comments.
+
+    If and when specific configurations for different sample types are introduced then the parametrisation can be
+    extended to allow these adding their names under "config" and introducing specific parameters that may differe
+    between the configuration files.
+    """
+    # Setup argparse.Namespace with the tests parameters
+    args = argparse.Namespace()
+    args.filename = filename
+    args.output_dir = tmp_path
+    args.config = config
+    args.simple = False
+
+    # Write default config with comments to file
+    io.create_config(args)
+
+    # Read the written config
+    with Path.open(tmp_path / expected_filename, encoding="utf-8") as f:
+        written_config = f.read()
+
+    # Validate that the written config has comments in it
+    assert "Config file generated" in written_config
+    assert "For more information on configuration and how to use it" in written_config
+    # Validate some of the parameters are present
+    assert "log_level:" in written_config
+    assert "output_dir: output" in written_config
+    assert "bam_file: data/bam/.bam" in written_config
+    assert "vcf_file: data/vcf/" in written_config
+
+
+def test_write_yaml(tmp_path: Path) -> None:
+    """Test reading of YAML file."""
+    io.write_yaml(
+        config=CONFIG,
+        output_dir=tmp_path,
+        config_file="test.yaml",
+        header_message="This is a test YAML configuration file",
+    )
+    outfile = tmp_path / "test.yaml"
+    assert outfile.is_file()
+
+
+def test_load_bam() -> None:
+    """Test loading of bam file."""
+    # bam = io.load_bam()
+    pass
+
+
+def test_load_bed() -> None:
+    """Test loading of bed file."""
+    # bed = io.load_bam()
+    pass
+
+
+def test_load_gtf() -> None:
+    """Test loading of gtf file."""
+    # gtf = io.load_bed()
+    pass
+
+
+def test_load_vcf() -> None:
+    """Test loading of vcf file."""
+    # vcf = io.load_vcf()
+    pass

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from isoslam import processing
+from isoslam import io, processing
 
 
 @pytest.mark.parametrize(
@@ -90,6 +90,21 @@ def test_entry_point_help(option: str, help_message: str, capsys: pytest.Capture
                 "vcf_file": Path("data/vcf/some.vcf.gz"),
             },
             id="dummy config and output, process with all files",
+        ),
+        pytest.param(
+            [
+                "create-config",
+                "--filename",
+                "test_config.yaml",
+                "--output-dir",
+                "custom_configs",
+            ],
+            io.create_config,
+            {
+                "filename": Path("test_config.yaml"),
+                "output_dir": Path("custom_configs"),
+            },
+            id="create config file",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+"""Test the utilities module and functions."""
+
+from pathlib import Path
+
+import pytest
+
+from isoslam import utils
+
+
+@pytest.mark.parametrize(
+    ("sample_config", "new_values", "expected_config"),
+    [
+        pytest.param(
+            {
+                "a": 1,
+                "b": 2,
+                "c": "something",
+                "base_dir": "here",
+                "output_dir": "there",
+            },
+            {"c": "something new"},
+            {
+                "a": 1,
+                "b": 2,
+                "c": "something new",
+                "base_dir": Path("here"),
+                "output_dir": Path("there"),
+            },
+            id="Change value of c",
+        ),
+    ],
+)
+def test_update_config(
+    sample_config: dict, new_values: dict, expected_config: dict, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test updating configuration."""
+    updated_config = utils.update_config(sample_config, new_values)
+
+    assert isinstance(updated_config, dict)
+    assert updated_config == expected_config


### PR DESCRIPTION
Closes #72

Adds `isoslam/default_config.yaml` along with `isoslam.io` and `isoslam.utils` modules which handle reading and writing
YAML files and configuration files.

Also adds a `isoslam create-config` sub-parser to the entry-point.