### PR TITLE
feature(io): Adds factory method to read .bam & .vcf

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-allow-list=
+extension-pkg-allow-list=pysam
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may

--- a/isoslam/io.py
+++ b/isoslam/io.py
@@ -1,14 +1,16 @@
 """Module for reading files."""
 
 import argparse
+from collections.abc import Callable
 from datetime import datetime
 from importlib import resources
 from pathlib import Path
+from typing import Any
+
+import pysam
 
 # from cgatcore import iotools
 from loguru import logger
-
-# import pysam
 from ruamel.yaml import YAML, YAMLError
 
 CONFIG_DOCUMENTATION_REFERENCE = """# For more information on configuration and how to use it see:
@@ -157,21 +159,104 @@ def create_config(args: argparse.Namespace | None = None) -> None:
     logger.info(CONFIG_DOCUMENTATION_REFERENCE)
 
 
-def load_bam() -> None:
-    """Load '.bam' file."""
-    return
+def load_file(file_path: str | Path) -> Any:
+    """
+    Load files.
+
+    Parameters
+    ----------
+    file_path : str | Path
+        Path to file to load.
+
+    Returns
+    -------
+    Any
+        Returns the loaded file as an object.
+    """
+    file_suffix = Path(file_path).suffix
+    if file_suffix == ".gz":
+        file_suffix = "".join(Path(file_path).suffixes)
+    loader = _get_loader(file_suffix)
+    return loader(file_path)
 
 
-def load_bed() -> None:
+def _get_loader(file_ext: str = "bam") -> Callable:  # type: ignore[type-arg]
+    """
+    Creator component which determines which file loader to use.
+
+    Parameters
+    ----------
+    file_ext : str
+        File extension of file to be loaded.
+
+    Returns
+    -------
+    function
+        Returns the function appropriate for the required file type to be loaded.
+
+    Raises
+    ------
+    ValueError
+        Unsupported file extension results in ValueError.
+    """
+    if file_ext == ".bam":
+        return _load_bam
+    if file_ext == ".bed":
+        return _load_bed
+    if file_ext == ".gtf":
+        return _load_gtf
+    if file_ext == ".vcf":
+        return _load_vcf
+    if file_ext == ".vcf.gz":
+        return _load_vcf
+    raise ValueError(file_ext)
+
+
+def _load_bam(bam_file: str | Path) -> pysam.libcalignmentfile.AlignmentFile:
+    """
+    Load '.bam' file.
+
+    Parameters
+    ----------
+    bam_file : str | Path
+        Path, as string or pathlib Path, to a '.bam' file that is to be loaded.
+
+    Returns
+    -------
+    pysam.libcalignmentfile.AlignmentFile
+        Loads the specified alignment file.
+    """
+    try:
+        return pysam.AlignmentFile(bam_file)
+    except FileNotFoundError as e:
+        raise e
+
+
+def _load_bed() -> None:
     """Load '.bed' file."""
     return
 
 
-def load_gtf() -> None:
+def _load_gtf() -> None:
     """Load '.bed' file."""
     return
 
 
-def load_vcf() -> None:
-    """Load '.vcf' file."""
-    return
+def _load_vcf(vcf_file: str | Path) -> pysam.libcbcf.VariantFile:
+    """
+    Load '.vcf' file.
+
+    Parameters
+    ----------
+    vcf_file : str | Path
+        Path, as string or pathlib Path, to a '.vcf' file that is to be loaded.
+
+    Returns
+    -------
+    pysam.libcbcf.VariantFile
+        Loads the specified VCF file.
+    """
+    try:
+        return pysam.VariantFile(vcf_file)
+    except FileNotFoundError as e:
+        raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,7 @@ exclude = [
 ]
 
 [[tool.mypy.overrides]]
-module = [ "numpy.*", "loguru", "ruamel.yaml"]
+module = [ "numpy.*", "loguru", "ruamel.yaml", "pysam"]
 ignore_missing_imports = true
 
 [project.scripts]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,9 +1,12 @@
 """Test the io.py module."""
 
 import argparse
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
+import pysam
 import pytest
 
 from isoslam import io
@@ -118,25 +121,158 @@ def test_write_yaml(tmp_path: Path) -> None:
     assert outfile.is_file()
 
 
-def test_load_bam() -> None:
+@pytest.mark.parametrize(
+    ("file_path", "object_type", "description", "compression"),
+    [
+        pytest.param(
+            RESOURCES / "bam" / "d0_0hr1_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            "BAM version 1 compressed sequence data",
+            "BGZF",
+            id="file 0hr1 as Path",
+        ),
+        pytest.param(
+            "tests/resources/bam/d0_0hr1_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            "BAM version 1 compressed sequence data",
+            "BGZF",
+            id="file 0hr1 as str",
+        ),
+        pytest.param(
+            RESOURCES / "bam" / "d0_no4sU_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            "BAM version 1 compressed sequence data",
+            "BGZF",
+            id="file no4sU as Path",
+        ),
+        pytest.param(
+            "tests/resources/bam/d0_no4sU_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            "BAM version 1 compressed sequence data",
+            "BGZF",
+            id="file no4sU as str",
+        ),
+    ],
+)
+def test_load_bam(
+    file_path: str | Path,
+    object_type: pysam.libcalignmentfile.AlignmentFile,
+    description: str,
+    compression: str,
+) -> None:
     """Test loading of bam file."""
-    # bam = io.load_bam()
-    pass
+    bam_file = io._load_bam(file_path)
+    assert isinstance(bam_file, object_type)
+    assert bam_file.description == description
+    assert bam_file.compression == compression
 
 
-def test_load_bed() -> None:
+@pytest.mark.skip
+@pytest.mark.parametrize(
+    ("file_path", "object_type"),
+    [
+        pytest.param(RESOURCES / "bed" / "test_coding_introns.bed", str, id="bed file as Path"),
+        pytest.param("tests/resources/bed/test_coding_introns.bed", str, id="bed file as str"),
+    ],
+)
+def test_load_bed(file_path: str | Path, object_type: str) -> None:
     """Test loading of bed file."""
-    # bed = io.load_bam()
-    pass
+    bed_file = io._load_bam()
+    assert isinstance(bed_file, object_type)
 
 
-def test_load_gtf() -> None:
+@pytest.mark.skip
+@pytest.mark.parametrize(
+    ("file_path", "object_type"),
+    [
+        pytest.param(RESOURCES / "gtf" / "test_wash1.gtf", str, id="gtf file as Path"),
+        pytest.param("tests/resources/gtf/test_wash1.gtf", str, id="gtf file as str"),
+    ],
+)
+def test_load_gtf(file_path: str | Path, object_type: str) -> None:
     """Test loading of gtf file."""
-    # gtf = io.load_bed()
-    pass
+    gtf_file = io._load_bed()
+    assert isinstance(gtf_file, object_type)
 
 
-def test_load_vcf() -> None:
+@pytest.mark.parametrize(
+    ("file_path", "object_type", "compression", "is_remote"),
+    [
+        pytest.param(RESOURCES / "vcf" / "d0.vcf.gz", pysam.libcbcf.VariantFile, "BGZF", False, id="d0 as Path"),
+        pytest.param("tests/resources/vcf/d0.vcf.gz", pysam.libcbcf.VariantFile, "BGZF", False, id="d0 as str"),
+    ],
+)
+def test_load_vcf(
+    file_path: str | Path, object_type: pysam.libcbcf.VariantFile, compression: str, is_remote: bool
+) -> None:
     """Test loading of vcf file."""
-    # vcf = io.load_vcf()
-    pass
+    vcf_file = io._load_vcf(file_path)
+    assert isinstance(vcf_file, object_type)
+    assert vcf_file.compression == compression
+    assert vcf_file.is_remote == is_remote
+
+
+@pytest.mark.parametrize(
+    ("file_ext", "function"),
+    [
+        pytest.param(".bam", io._load_bam, id="bam extension"),
+        pytest.param(".bed", io._load_bed, id="bed extension"),
+        pytest.param(".gtf", io._load_gtf, id="gtf extension"),
+        pytest.param(".vcf", io._load_vcf, id="vcf extension"),
+        pytest.param(".vcf.gz", io._load_vcf, id="vcf.gz extension"),
+    ],
+)
+def test_get_loader(file_ext: str, function: Callable) -> None:
+    """Test io._get_loader returns the correct function."""
+    assert io._get_loader(file_ext) == function
+
+
+@pytest.mark.parametrize(
+    ("file_ext"),
+    [
+        pytest.param(".csv", id="csv extension"),
+        pytest.param(".txt", id="txt extension"),
+        pytest.param(".tar.gz", id="tar.gz extension"),
+    ],
+)
+def test_get_loader_value_error(file_ext: str) -> None:
+    """Test io._get_loader() raises ValueError with incorrect file extension."""
+    with pytest.raises(ValueError):  # noqa: PT011
+        io._get_loader(file_ext)
+
+
+@pytest.mark.parametrize(
+    ("file_path", "object_type"),
+    [
+        pytest.param(
+            RESOURCES / "bam" / "d0_0hr1_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            id="bam file 0hr1 as Path",
+        ),
+        pytest.param(
+            "tests/resources/bam/d0_0hr1_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            id="bam file 0hr1 as str",
+        ),
+        pytest.param(
+            RESOURCES / "bam" / "d0_no4sU_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            id="bam file no4sU as Path",
+        ),
+        pytest.param(
+            "tests/resources/bam/d0_no4sU_filtered_remapped_sorted.bam",
+            pysam.libcalignmentfile.AlignmentFile,
+            id="bam file no4sU as str",
+        ),
+        # pytest.param(RESOURCES / "bed" / "test_coding_introns.bed", id="bed file as Path"),
+        # pytest.param("tests/resources/bed/test_coding_introns.bed", id="bed file as str"),
+        # pytest.param(RESOURCES / "gtf" / "test_wash1.gtf", id="gtf file as Path"),
+        # pytest.param("tests/resources/gtf/test_wash1.gtf", id="gtf file as str"),
+        pytest.param(RESOURCES / "vcf" / "d0.vcf.gz", pysam.libcbcf.VariantFile, id="d0 as Path"),
+        pytest.param("tests/resources/vcf/d0.vcf.gz", pysam.libcbcf.VariantFile, id="d0 as str"),
+    ],
+)
+def test_load_file(file_path: str | Path, object_type: Any) -> None:
+    """Test loading of files."""
+    file = io.load_file(file_path)
+    assert isinstance(file, object_type)


### PR DESCRIPTION
Adds a generic factory method for loading files based on file extension.

- Loads `.bam` with test of properties.
- Loads `.vcf`with test of properties.
- Implements tests for each (private) method and the factory components `load_file()` and `get_loader()`.

Mostly typed.

Need to find alternatives to `cgat` for loading `.gtf` and `.bed` and add these in.

**NB** Tests pass locally, they _won't_ pass on CI at the moment as `cgat` won't currently install during setup (see #77). Whilst ultimately we can look to remove the dependency on `cgat` for loading `.gtf` and `.bed` files for now we need to retain the dependency because the regression test for `isoslam/all_introns_counts_and_info.py` does use this library.