### PR TITLE
ci/style: Trying to ignore files that won't be type checked

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,11 @@ repos:
     hooks:
       - id: mypy
         files: isoslam
-        args: []
+        args:
+          [
+            "--exclude='^all_introns_counts_and_info\\.py$'",
+            "--exclude='^pipeline_slam_3UIs\\.py$'",
+          ]
 
   # @ns-rse (2024-11-27) Currently fails due to `fastjsonschema` not covering `tool.ruff.lint` see
   # https://github.com/abravalheri/validate-pyproject/issues/180

--- a/isoslam/all_introns_counts_and_info.py
+++ b/isoslam/all_introns_counts_and_info.py
@@ -12,6 +12,8 @@ read, checks these are not present in the SNP VCF file, and outputs metadata on 
 about it's event assignment, number of conversions, coverage etc.
 """
 
+# mypy: ignore-errors
+
 from argparse import ArgumentParser
 import sys
 

--- a/isoslam/pipeline_slam_3UIs.py
+++ b/isoslam/pipeline_slam_3UIs.py
@@ -4,11 +4,14 @@ annotates them, then passes them detects and quantifies the number
 of 4sU-linked nucleotide conversions (T>C or A>G), exclusing SNPs.
 """
 
+# mypy: ignore-errors
+
 import os
 import sys
 
 import ruffus
 from cgatcore import pipeline as P
+
 
 # Read in pipeline.yml
 PARAMS = P.get_parameters(

--- a/isoslam/pipeline_slam_3UIs/all_introns_counts_and_info.py
+++ b/isoslam/pipeline_slam_3UIs/all_introns_counts_and_info.py
@@ -2,15 +2,17 @@
 all_introns_counts_and_info.py
 ====================
 Takes in the sorted and feature assigned `.bam` file from previous steps and passes them to a
-python script that uses pysam (python wrapper for htslib). This script iterates over the `.bam` 
+python script that uses pysam (python wrapper for htslib). This script iterates over the `.bam`
 file pair-by-pair (representing the sequencing insert), determines whether the read-pair shows
 evidence of intron splicing/retention and assigns these to specific events by referencing the
 `.gtf` and `.bed` files, and XT tag from featureCountsReadAssignments. Next, the script uses the
 XS tag from featureCountsReadAssignment to assign each read in the pair as the forward or reverse
 read, relative to the direction of transcription. Finally, it looks for T>C in FW read, A>G in RV
 read, checks these are not present in the SNP VCF file, and outputs metadata on each read-pair
-about it's event assignment, number of conversions, coverage etc. 
+about it's event assignment, number of conversions, coverage etc.
 """
+
+# mypy: ignore-errors
 
 import sys
 from collections import defaultdict
@@ -52,7 +54,7 @@ def main(argv=None):
         "--out",
         dest="outfile_tsv",
         type=str,
-        help="""Supply a path to the output file. This file will contain 
+        help="""Supply a path to the output file. This file will contain
                         conversions per pair, accounting for stranding""",
     )
 
@@ -108,7 +110,6 @@ def main(argv=None):
     conversion_dict = defaultdict(int)
 
     def fragment_iterator(read_iterator):
-
         read_list = list()
         last_read = None
 
@@ -137,7 +138,6 @@ def main(argv=None):
         )
 
         for pair in fragment_iterator(bamfile.fetch(until_eof=True)):
-
             # if i_total_progress >= 2000000:
             ##    print("length break")
             #    break
@@ -461,7 +461,6 @@ def main(argv=None):
                             converted_position.add(genome_pos)
 
                 for base in reverse_read.get_aligned_pairs(with_seq=True):
-
                     read_pos, genome_pos, genome_seq = base
                     if None in base:
                         continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,7 @@ python_version = "3.10"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
+warn_unused_ignores = true
 exclude = [
   '^all_introns_counts_and_info\.py$',
   '^pipeline_slam_3UIs\.py$',


### PR DESCRIPTION
Tried various combinations to exclude based on the [official
documentation](https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude) as well as adding an explicit `# type: ignore` to the top of the files that should be ignored but `mypy` is still trying to check these for some reason. :shrug:

Ultimately the solution was to use `# mypy: ignore-exceptions` at the head of the file.

Have added some additional configuration options to `mypy` configuration in `pyproject.toml` and `.pre-commit-config.yaml` anyway.