### PR TITLE
feature(utils): Rounds out updating configuration

### DIFF
--- a/isoslam/utils.py
+++ b/isoslam/utils.py
@@ -1,10 +1,26 @@
 """Utilities and helper functionsfor IsoSLAM."""
 
 from argparse import Namespace
+from pathlib import Path
 
 from loguru import logger
 
-from isoslam import io
+
+def convert_path(path: str | Path) -> Path:
+    """
+    Ensure path is Path object.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to be converted.
+
+    Returns
+    -------
+    Path
+        Pathlib object of path.
+    """
+    return Path().cwd() if path == "./" else Path(path).expanduser()
 
 
 def update_config(config: dict, args: dict | Namespace) -> dict:  # type: ignore[type-arg]
@@ -35,7 +51,7 @@ def update_config(config: dict, args: dict | Namespace) -> dict:  # type: ignore
                 config[arg_key] = arg_value
                 logger.debug(f"Updated config config[{arg_key}] : {original_value} > {arg_value} ")
     if "base_dir" in config.keys():
-        config["base_dir"] = io._str_to_path(config["base_dir"])  # pylint: disable=protected-access
+        config["base_dir"] = convert_path(config["base_dir"])  # pylint: disable=protected-access
     if "output_dir" in config.keys():
-        config["output_dir"] = io._str_to_path(config["output_dir"])  # pylint: disable=protected-access
+        config["output_dir"] = convert_path(config["output_dir"])  # pylint: disable=protected-access
     return config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,11 +30,11 @@ from isoslam import utils
         ),
     ],
 )
-def test_update_config(
-    sample_config: dict, new_values: dict, expected_config: dict, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_update_config(sample_config: dict, new_values: dict, expected_config: dict) -> None:
     """Test updating configuration."""
     updated_config = utils.update_config(sample_config, new_values)
 
     assert isinstance(updated_config, dict)
     assert updated_config == expected_config
+    assert isinstance(updated_config["base_dir"], Path)
+    assert isinstance(updated_config["output_dir"], Path)


### PR DESCRIPTION
Main function `update_config()` was already in place, this rounds it out by converting the values associated with the
keys `base_dir` and `output_dir` to be objects of type `Path` so they are easy to use in subsequent processing.

Will have to ensure in each processor function that after the configuration is loaded a call is made to
`utils.update_config()` so that values get updated.