### PR TITLE
ci: Install package and dependencies in mkdocs workflow

### DIFF
--- a/.github/workflows/mkdocs-deploy.yaml
+++ b/.github/workflows/mkdocs-deploy.yaml
@@ -12,6 +12,15 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v1
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install package and dependencies
+        run: |
+          pip3 install .[docs]
+
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:


### PR DESCRIPTION
Build and deploy [failed](https://github.com/sudlab/IsoSLAM/actions/runs/12414815741/job/34659727443) because the
plugins weren't available.

```
Run mhausenblas/mkdocs-deploy-gh-pages@master
/usr/bin/docker run --name db7685fc3044df684962aa4924ad34f3fab3_852eea --label 16db76 --workdir /github/workspace --rm -e "GITHUB_TOKEN" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVI
INFO: setup with GITHUB_TOKEN
ERROR   -  Config value 'plugins': The "mermaid2" plugin is not installed
Aborted with 1 configuration errors!
```

We therefore setup Python and install the package and its optional dependencies for docs.