### PR TITLE
ci: switch to native mkdocs gh-deploy

### DIFF
--- a/.github/workflows/mkdocs-deploy.yaml
+++ b/.github/workflows/mkdocs-deploy.yaml
@@ -20,8 +20,4 @@ jobs:
       - name: Install package and dependencies
         run: |
           pip3 install .[docs]
-
-      - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          mkdocs gh-deploy


### PR DESCRIPTION
Don't want to have to add `EXTRA_PACKAGES` or a `requirements.txt` and refer to it via `REQUIREMENTS` in the
configuration of [mhausenblas/mkdocs-deploy-gh-pages](https://github.com/mhausenblas/mkdocs-deploy-gh-pages).

Instead lets see if we can use `mkdocs gh-deploy` in a custom step.