### PR TITLE
ci: Correcting action version

### DIFF
--- a/.github/workflows/build_mkdocs.yaml
+++ b/.github/workflows/build_mkdocs.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "."
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
I got confused between `actions/upload-artifact` and `actions/upload-pages-artifact`.

For `actions/upload-artifact` the `@v3` is due to be deprecated (see
[here](https://github.com/actions/upload-artifact#breaking-changes) and
[here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)) but this action doesn't even use that
action so I shouldn't have updated it!

Must pay closer attention in the future.