### PR TITLE
refactor: extract untranslated regions from assigned reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,4 +178,8 @@ cython_debug/
 # pytest-testmon
 .testmon*
 
+# Misc
 tmp/
+data/
+bin/
+output/

--- a/isoslam/isoslam.py
+++ b/isoslam/isoslam.py
@@ -126,7 +126,7 @@ def extract_features_from_read(read: AlignedSegment) -> dict[str, int | str | No
     return {
         "start": read.reference_start,
         "end": read.reference_end,
-        "length": read.reference_length,
+        "length": read.query_length,
         "status": status,
         "transcript": transcript,
         "block_start": block_start,
@@ -154,27 +154,28 @@ def extract_features_from_pair(pair: list[AlignedSegment]) -> dict[str, dict[str
     }
 
 
-# def extract_utron(read: AlignedSegment, transcript_to_gene: Any, tag: str = "XS") -> list | None:
-#     """
-#     Extract and sum the utrons based on tag.
+def extract_utron(features: dict[str, Any], gene_transcript: Any, coordinates: Any) -> list[tuple[int | str]] | None:
+    """
+    Extract and sum the utrons based on tag.
 
-#     ACTION : This function needs better documentation, my guess is that its extracting the transcripts to genes and
-#     then getting some related information (what I'm not sure) from the .bed file and adding these up.
+    ACTION : This function needs better documentation, my guess is that its extracting the transcripts to genes and
+    then getting some related information (what I'm not sure) from the .bed file and adding these up.
 
-#     Parameters
-#     ----------
-#     read : AlignedSegement
-#         An aligned segment read.
-#     transcript_to_gene : TextIO
-#         Transcript to gene from a ``.bed`` file.
-#     tag : str
-#         Type of tag to extract.
+    Parameters
+    ----------
+    features : str
+        A tag from an assigned read.
+    gene_transcript : TextIO
+        Transcript to gene from a ``.gtf`` file.
+    coordinates : Any
+        Untranslated region coordinates from a ``.bed`` file.
 
-#     Returns
-#     -------
-#     list | None
-#         List of the length of assigned regions.
-#     """
-#     if read.get_tag(tag) == "Assigned":
-#         return sum(bed_file[transcript] for transcript in tx2gene[read.get_tag("XT")])
-#     return None
+    Returns
+    -------
+    list | None
+        List of the length of assigned regions.
+    """
+    if features["status"] == "Assigned":
+        untranslated_regions = [coordinates[transcript] for transcript in gene_transcript[features["transcript"]]]
+        return sum(untranslated_regions, [])
+    return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,11 @@
 from pathlib import Path
 from typing import Any
 
+import pysam
 import pytest
 from pysam import AlignedSegment, AlignmentFile
 
-from isoslam import io
+from isoslam import io, isoslam
 
 BASE_DIR = Path.cwd()
 TEST_DIR = BASE_DIR / "tests"
@@ -36,6 +37,30 @@ def bam_file2() -> AlignmentFile:
 def bam_unaligned_file1() -> AlignmentFile:
     """Load an unsorted and unassigned ``.bam`` file (ignore the filename!)."""
     return io.load_file(BAM_DIR / "d0_no4sU_filtered_remapped_sorted.bam")
+
+
+@pytest.fixture()
+def gtf_file() -> pysam.tabix_generic_iterator:
+    """Load a ``.gtf`` file."""
+    return io.load_file(GTF_DIR / "test_wash1.gtf")
+
+
+@pytest.fixture()
+def bed_file() -> dict:
+    """Load a ``.gtf`` file."""
+    return io.load_file(BED_DIR / "test_coding_introns.bed")
+
+
+@pytest.fixture()
+def extract_strand_transcript() -> tuple[dict, dict]:
+    """Tuple of dictionaries from ``.gtf`` file."""
+    return isoslam.extract_strand_transcript(GTF_DIR / "test_wash1.gtf")
+
+
+@pytest.fixture()
+def extract_transcript() -> dict:
+    """Extract dictionary of transcripts from ``.bed`` file."""
+    return isoslam.extract_transcripts(BED_DIR / "test_coding_introns.bed")
 
 
 @pytest.fixture()

--- a/tests/test_isoslam.py
+++ b/tests/test_isoslam.py
@@ -232,3 +232,50 @@ def test_extract_features_from_pair(
     )
     assert isinstance(read_pair, dict)
     assert read_pair == expected
+
+
+@pytest.mark.parametrize(
+    ("aligned_segment", "transcript_id", "length"),
+    [
+        pytest.param(  # type: ignore[misc]
+            "aligned_segment_unassigned_28584",
+            "",
+            0,
+            id="28584 - Assignment and Transcript are None",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_17814",
+            "ENST00000442898",
+            10,
+            id="17814 - Assigned to MSTRG.63147",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_14770",
+            "ENST00000442898",
+            10,
+            id="14770 - Assigned to MSTRG.63147",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_15967",
+            "ENST00000442898",
+            10,
+            id="15967 - Assigned to MSTRG.63147",
+        ),
+    ],
+)
+def test_extract_utron(
+    aligned_segment: str,
+    transcript_id: str,
+    length: int,
+    extract_transcript: dict[str, list[int | str]],
+    extract_strand_transcript: tuple[dict[str, list[Any]], dict[str, str]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test extraction of the untranslated regions using extract_utron()."""
+    segment = isoslam.extract_features_from_read(request.getfixturevalue(aligned_segment))
+    _, gene_transcript = extract_strand_transcript
+    untranslated_region = isoslam.extract_utron(segment, gene_transcript, coordinates=extract_transcript)
+    assert isinstance(untranslated_region, list)
+    assert len(untranslated_region) == length
+    if len(untranslated_region):
+        assert untranslated_region[0][3] == transcript_id  # type: ignore[misc]

--- a/tests/test_isoslam.py
+++ b/tests/test_isoslam.py
@@ -100,7 +100,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_unassigned_28584",
             28584,
             28733,
-            149,
+            150,
             None,
             None,
             (28584, 28704),
@@ -111,7 +111,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_unassigned_17416",
             17416,
             17805,
-            389,
+            150,
             None,
             None,
             (17416, 17718),
@@ -122,7 +122,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_unassigned_18029",
             18029,
             18385,
-            356,
+            150,
             None,
             None,
             (18029, 18380),
@@ -133,7 +133,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_assigned_17814",
             17814,
             18136,
-            322,
+            150,
             "Assigned",
             "MSTRG.63147",
             (17814, 18027),
@@ -144,7 +144,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_assigned_14770",
             14770,
             14876,
-            106,
+            150,
             "Assigned",
             "MSTRG.63147",
             (14770,),
@@ -177,6 +177,7 @@ def test_extract_features_from_read(
 ) -> None:
     """Test extract of features from an unassigned and assigned segment reads."""
     segment = isoslam.extract_features_from_read(request.getfixturevalue(aligned_segment))
+    print(f"{segment['length']}")
     assert isinstance(segment, dict)
     assert segment["start"] == start
     assert segment["end"] == end
@@ -197,7 +198,7 @@ def test_extract_features_from_read(
                 "read1": {
                     "start": 17814,
                     "end": 18136,
-                    "length": 322,
+                    "length": 150,
                     "status": "Assigned",
                     "transcript": "MSTRG.63147",
                     "block_start": (17814, 18027),
@@ -206,7 +207,7 @@ def test_extract_features_from_read(
                 "read2": {
                     "start": 14770,
                     "end": 14876,
-                    "length": 106,
+                    "length": 150,
                     "status": "Assigned",
                     "transcript": "MSTRG.63147",
                     "block_start": (14770,),


### PR DESCRIPTION
Closes #89

Extracts the untranslated region coordinates from assigned transcript reads.

Reduces code duplication by abstracting repeated code into a function (`isoslam.extract(utron)`) and implements tests.

The regression test which checks that replacing the code in `all_introns_counts_and_info.py` produces the expected
results when replacing the old code with the newer code fails for one of the files here and I would appreciate insight
as to whether this is correct or not as I don't know if its a mistake in what I've introduced or a problem with the code
as it existed.

The failing test is...

```
tests/test_all_introns_counts_and_info.py::test_main[file 1] PASSED                                                                                      [ 50%]
tests/test_all_introns_counts_and_info.py::test_main[file 2] FAILED                                                                                      [100%]

=========================================== FAILURES ============================================================
________________________________________ test_main[file 2] ______________________________________________________

regression test output differences for tests/test_all_introns_counts_and_info.py::test_main[file 2]:
    (recorded output from tests/_regtest_outputs/test_all_introns_counts_and_info.test_main[file_2])

    >   --- current
    >   +++ expected
    >   @@ -819,13 +819,7 @@
    >    0       482  ENST00000442898  18492  24850   9      -        Ret            0           58       219
    >    0       483  ENST00000442898  18492  24850   9      -        Ret            0           58       219
    >    0       484  ENST00000442898  14940  15080   9      -        Ret            1           54       233
    >   -0       484  ENST00000442898  15149  15908   9      -        Ret            1           54       233
    >   -0       484  ENST00000442898  16061  16717   9      -        Ret            1           54       233
    >    0       484  ENST00000442898  16876  16964   9      -        Ret            1           54       233
    >   -0       484  ENST00000442898  17166  17343   9      -        Ret            1           54       233
    >   -0       484  ENST00000442898  17479  17718   9      -        Ret            1           54       233
    >   -0       484  ENST00000442898  17855  18027   9      -        Ret            1           54       233
    >   -0       484  ENST00000442898  18174  18380   9      -        Ret            1           54       233
    >    0       484  ENST00000442898  18492  24850   9      -        Ret            1           54       233
    >    0       485  ENST00000442898  17479  17718   9      -        Spl            0           62       293
    >    0       485  ENST00000442898  17855  18027   9      -        Spl            0           62       293

---------------------------------------- Captured stderr call ---------------------------------------------------
```

Which is a little hard to read but what it means is that in the existing output for this test (found in
`tests/_regtest_outputs/test_all_introns_counts_and_info.test_main[file_2]`) there are the following entries...

```
❱ grep 484 tests/_regtest_outputs/test_all_introns_counts_and_info.test_main\[file_2\].out | sort
0       484  ENST00000442898  14940  15080   9      -        Ret            1           54       233
0       484  ENST00000442898  16876  16964   9      -        Ret            1           54       233
0       484  ENST00000442898  18492  24850   9      -        Ret            1           54       233
```

In the output when running the refactored code there are six more entries which I've marked with a `*` below...

```
❱ grep 484 /tmp/pytest-of-neil/pytest-current/test_main_file_2_current/test.tsv | sort
484	ENST00000442898	14940	15080	9	-	Ret	1	54	233
484	ENST00000442898	15149	15908	9	-	Ret	1	54	233 *
484	ENST00000442898	16061	16717	9	-	Ret	1	54	233 *
484	ENST00000442898	16876	16964	9	-	Ret	1	54	233
484	ENST00000442898	17166	17343	9	-	Ret	1	54	233 *
484	ENST00000442898	17479	17718	9	-	Ret	1	54	233 *
484	ENST00000442898	17855	18027	9	-	Ret	1	54	233 *
484	ENST00000442898	18174	18380	9	-	Ret	1	54	233 *
484	ENST00000442898	18492	24850	9	-	Ret	1	54	233
```

I've no idea whether these six additional entries should be there or not. They look like they perhaps should be as the
`start` and `end` are within the limits of the original three entries but I don't know if that is means they should be
present or not.