### PR TITLE
tests: Expand fixtures

### DIFF
--- a/isoslam/all_introns_counts_and_info.py
+++ b/isoslam/all_introns_counts_and_info.py
@@ -150,8 +150,8 @@ def main(argv=None):
             ## If not, we should cull assignment to those events
             ## We are comparing ret vs spliced, so instead of adding 1 to both
             ## we will just ignore those few
-            block_starts1, block_ends1 = zip(*read1.get_blocks())
-            block_starts2, block_ends2 = zip(*read2.get_blocks())
+            block_starts1, block_ends1 = isoslam.zip_blocks(read1)
+            block_starts2, block_ends2 = isoslam.zip_blocks(read2)
             # RETAINED
             read1_within_intron = {}
 

--- a/isoslam/all_introns_counts_and_info.py
+++ b/isoslam/all_introns_counts_and_info.py
@@ -112,6 +112,9 @@ def main(argv=None):
 
             # Extract features
             pair_features = isoslam.extract_features_from_pair(pair)
+            # DEBUGGING - Get information on features
+            if i_total_progress in (484):
+                print(f"{pair_features=}")
             # Temporary code sets up variables from the returned dictionary to match those currently used
             read1_start = pair_features["read1"]["start"]
             read1_end = pair_features["read1"]["end"]

--- a/isoslam/isoslam.py
+++ b/isoslam/isoslam.py
@@ -1,7 +1,7 @@
 """IsoSLAM module."""
 
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -179,3 +179,20 @@ def extract_utron(features: dict[str, Any], gene_transcript: Any, coordinates: A
         untranslated_regions = [coordinates[transcript] for transcript in gene_transcript[features["transcript"]]]
         return sum(untranslated_regions, [])
     return []
+
+
+def zip_blocks(read: AlignedSegment) -> Iterator[tuple[Any, ...]]:
+    """
+    Zip the block starts and ends into two lists.
+
+    Parameters
+    ----------
+    read : AlignedSegment
+        An individual aligned segment read from a ''.bam'' file.
+
+    Returns
+    -------
+    tuple[list[int], list[int]]
+        Tuple of two lists of integers the first is start location, the second is the end location.
+    """
+    return zip(*read.get_blocks())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,24 +91,60 @@ def aligned_segment_unassigned_18029(bam_unaligned_file1: AlignmentFile) -> Alig
 
 
 @pytest.fixture()
-def bam_sorted_assigned_file() -> list[AlignedSegment]:
+def bam_sorted_assigned_file_no4sU() -> list[AlignedSegment]:
     """Return a list of a ``AlignedSegment`` from a ``.bam`` file that has been sorted and assigned."""
     return list(io.load_file(BAM_SORTED_ASSIGNED_DIR / "d0_no4sU_filtered_remapped_sorted.sorted.assigned.bam"))
 
 
 @pytest.fixture()
-def aligned_segment_assigned_15967(bam_sorted_assigned_file: list[AlignedSegment]) -> AlignedSegment:
+def aligned_segment_assigned_15967(bam_sorted_assigned_file_no4sU: list[AlignedSegment]) -> AlignedSegment:
     """Return a single assigned AlignedSegment where start is 15967."""
-    return [x for x in bam_sorted_assigned_file if x.reference_start == 15967][0]
+    return [x for x in bam_sorted_assigned_file_no4sU if x.reference_start == 15967][0]
 
 
 @pytest.fixture()
-def aligned_segment_assigned_14770(bam_sorted_assigned_file: list[AlignedSegment]) -> AlignedSegment:
+def aligned_segment_assigned_14770(bam_sorted_assigned_file_no4sU: list[AlignedSegment]) -> AlignedSegment:
     """Return a single assigned AlignedSegment where start is 14770."""
-    return [x for x in bam_sorted_assigned_file if x.reference_start == 14770][0]
+    return [x for x in bam_sorted_assigned_file_no4sU if x.reference_start == 14770][0]
 
 
 @pytest.fixture()
-def aligned_segment_assigned_17814(bam_sorted_assigned_file: list[AlignedSegment]) -> AlignedSegment:
+def aligned_segment_assigned_17814(bam_sorted_assigned_file_no4sU: list[AlignedSegment]) -> AlignedSegment:
     """Return a single assigned AlignedSegment where start is 17814."""
-    return [x for x in bam_sorted_assigned_file if x.reference_start == 17814][0]
+    return [x for x in bam_sorted_assigned_file_no4sU if x.reference_start == 17814][0]
+
+
+@pytest.fixture()
+def bam_sorted_assigned_file_0hr1() -> list[AlignedSegment]:
+    """Return a list of a ``AlignedSegment`` from a ``.bam`` file that has been sorted and assigned."""
+    return list(io.load_file(BAM_SORTED_ASSIGNED_DIR / "d0_0hr1_filtered_remapped_sorted.sorted.assigned.bam"))
+
+
+@pytest.fixture()
+def aligned_segment_assigned_21051(bam_sorted_assigned_file_0hr1: list[AlignedSegment]) -> AlignedSegment:
+    """
+    Return a single assigned AlignedSegment where start is 21051.
+
+    Along with the next fixture (20906) this was the 484th pair of reads that caused some early problems with regression
+    tests which is why they have been pulled out and added to the parameterised tests.
+
+    The reason these problems occurred is because initially 9 alignments are found at this location but 6 of these
+    should be filtered out subsequently, a mistake in refactoring used the wrong length. But this will serve as a useful
+    aligned segment to be testing because of this filtering.
+    """
+    return [x for x in bam_sorted_assigned_file_0hr1 if x.reference_start == 21051][0]
+
+
+@pytest.fixture()
+def aligned_segment_assigned_20906(bam_sorted_assigned_file_0hr1: list[AlignedSegment]) -> AlignedSegment:
+    """
+    Return a single assigned AlignedSegment where start is 20906.
+
+    Along with the previous fixture (21051) this was the 484th pair of reads that cause some early problems with
+    regression tests which is why they have been pulled out and added to the parameterised tests.
+
+    The reason these problems occurred is because initially 9 alignments are found at this location but 6 of these
+    should be filtered out subsequently, a mistake in refactoring used the wrong length. But this will serve as a useful
+    aligned segment to be testing because of this filtering.
+    """
+    return [x for x in bam_sorted_assigned_file_0hr1 if x.reference_start == 20906][0]

--- a/tests/test_isoslam.py
+++ b/tests/test_isoslam.py
@@ -162,6 +162,28 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             (16117,),
             id="15967 - Assigned to MSTRG.63147",
         ),
+        pytest.param(
+            "aligned_segment_assigned_21051",
+            21051,
+            21201,
+            150,
+            "Unassigned_NoFeatures",
+            None,
+            (21051,),
+            (21201,),
+            id="21051 - Unassigned",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_20906",
+            20906,
+            21056,
+            150,
+            "Unassigned_NoFeatures",
+            None,
+            (20906,),
+            (21056,),
+            id="20906 - Unassigned",
+        ),
     ],
 )
 def test_extract_features_from_read(
@@ -177,7 +199,7 @@ def test_extract_features_from_read(
 ) -> None:
     """Test extract of features from an unassigned and assigned segment reads."""
     segment = isoslam.extract_features_from_read(request.getfixturevalue(aligned_segment))
-    print(f"{segment['length']}")
+    print(f"{segment=}")
     assert isinstance(segment, dict)
     assert segment["start"] == start
     assert segment["end"] == end
@@ -214,7 +236,32 @@ def test_extract_features_from_read(
                     "block_end": (14876,),
                 },
             },
-            id="28584 and 17416 - Assignment and Transcript are None",
+            id="28584 and 17416 - Assigned and transcript MSTRG.63147",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_21051",
+            "aligned_segment_assigned_20906",
+            {
+                "read1": {
+                    "start": 21051,
+                    "end": 21201,
+                    "length": 150,
+                    "status": "Unassigned_NoFeatures",
+                    "transcript": None,
+                    "block_start": (21051,),
+                    "block_end": (21201,),
+                },
+                "read2": {
+                    "start": 20906,
+                    "end": 21056,
+                    "length": 150,
+                    "status": "Unassigned_NoFeatures",
+                    "transcript": None,
+                    "block_start": (20906,),
+                    "block_end": (21056,),
+                },
+            },
+            id="21051 and 21056 - Assignment and Transcript are None",
         ),
     ],
 )
@@ -262,6 +309,18 @@ def test_extract_features_from_pair(
             10,
             id="15967 - Assigned to MSTRG.63147",
         ),
+        pytest.param(
+            "aligned_segment_assigned_21051",
+            None,
+            0,
+            id="21051 - Unassigned",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_20906",
+            None,
+            0,
+            id="20906 - Unassigned",
+        ),
     ],
 )
 def test_extract_utron(
@@ -308,6 +367,18 @@ def test_extract_utron(
             (15967,),
             (16117,),
             id="15967 - Assigned to MSTRG.63147",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_21051",
+            (21051,),
+            (21201,),
+            id="21051 - Unassigned",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_20906",
+            (20906,),
+            (21056,),
+            id="20906 - Unassigned",
         ),
     ],
 )

--- a/tests/test_isoslam.py
+++ b/tests/test_isoslam.py
@@ -100,7 +100,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_unassigned_28584",
             28584,
             28733,
-            149,
+            150,
             None,
             None,
             (28584, 28704),
@@ -111,7 +111,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_unassigned_17416",
             17416,
             17805,
-            389,
+            150,
             None,
             None,
             (17416, 17718),
@@ -122,7 +122,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_unassigned_18029",
             18029,
             18385,
-            356,
+            150,
             None,
             None,
             (18029, 18380),
@@ -133,7 +133,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_assigned_17814",
             17814,
             18136,
-            322,
+            150,
             "Assigned",
             "MSTRG.63147",
             (17814, 18027),
@@ -144,7 +144,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "aligned_segment_assigned_14770",
             14770,
             14876,
-            106,
+            150,
             "Assigned",
             "MSTRG.63147",
             (14770,),
@@ -177,6 +177,7 @@ def test_extract_features_from_read(
 ) -> None:
     """Test extract of features from an unassigned and assigned segment reads."""
     segment = isoslam.extract_features_from_read(request.getfixturevalue(aligned_segment))
+    print(f"{segment['length']}")
     assert isinstance(segment, dict)
     assert segment["start"] == start
     assert segment["end"] == end
@@ -197,7 +198,7 @@ def test_extract_features_from_read(
                 "read1": {
                     "start": 17814,
                     "end": 18136,
-                    "length": 322,
+                    "length": 150,
                     "status": "Assigned",
                     "transcript": "MSTRG.63147",
                     "block_start": (17814, 18027),
@@ -206,7 +207,7 @@ def test_extract_features_from_read(
                 "read2": {
                     "start": 14770,
                     "end": 14876,
-                    "length": 106,
+                    "length": 150,
                     "status": "Assigned",
                     "transcript": "MSTRG.63147",
                     "block_start": (14770,),

--- a/tests/test_isoslam.py
+++ b/tests/test_isoslam.py
@@ -279,3 +279,44 @@ def test_extract_utron(
     assert len(untranslated_region) == length
     if len(untranslated_region):
         assert untranslated_region[0][3] == transcript_id  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("aligned_segment", "expected_start", "expected_end"),
+    [
+        pytest.param(  # type: ignore[misc]
+            "aligned_segment_unassigned_28584",
+            (28584, 28704),
+            (28704, 28733),
+            id="28584 - Assignment and Transcript are None",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_17814",
+            (17814, 18027),
+            (17855, 18136),
+            id="17814 - Assigned to MSTRG.63147",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_14770",
+            (14770,),
+            (14876,),
+            id="14770 - Assigned to MSTRG.63147",
+        ),
+        pytest.param(
+            "aligned_segment_assigned_15967",
+            (15967,),
+            (16117,),
+            id="15967 - Assigned to MSTRG.63147",
+        ),
+    ],
+)
+def test_zip_blocks(
+    aligned_segment: str,
+    expected_start: tuple[int],
+    expected_end: tuple[int],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test that block starts and ends are zipped correctly."""
+    start_blocks, end_blocks = isoslam.zip_blocks(request.getfixturevalue(aligned_segment))
+    assert start_blocks == expected_start
+    assert end_blocks == expected_end


### PR DESCRIPTION
Closes #131

Adds in a couple of aligned reads that have some utrons dropped, will be useful in future tests.