### PR TITLE
ci: Adds todo-md pre-commit hook and an item

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -16,6 +16,7 @@ globs:
 ignores:
   - "tmp/**/*.md"
   - "docs/api/**/*.md"
+  - TODO.md
 
 # Fix any fixable errors
 fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,11 @@ repos:
             "--exclude='^pipeline_slam_3UIs\\.py$'",
           ]
 
+  - repo: https://codeberg.org/lig/todo-md.git
+    rev: v1.0.2
+    hooks:
+      - id: todo-md
+
   # @ns-rse (2024-11-27) Currently fails due to `fastjsonschema` not covering `tool.ruff.lint` see
   # https://github.com/abravalheri/validate-pyproject/issues/180
   # Disabling for now

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+- [isoslam/all_introns_counts_and_info.py:315](isoslam/all_introns_counts_and_info.py#L315): Move logic to earlier in work flow and skip more preocessing if evaluate to False

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-* [isoslam/all_introns_counts_and_info.py:315](isoslam/all_introns_counts_and_info.py#L315): Move logic to earlier in work flow and skip more preocessing if evaluate to False

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+* [isoslam/all_introns_counts_and_info.py:315](isoslam/all_introns_counts_and_info.py#L315): Move logic to earlier in work flow and skip more preocessing if evaluate to False

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-- [isoslam/all_introns_counts_and_info.py:315](isoslam/all_introns_counts_and_info.py#L315): Move logic to earlier in work flow and skip more preocessing if evaluate to False

--- a/isoslam/all_introns_counts_and_info.py
+++ b/isoslam/all_introns_counts_and_info.py
@@ -113,7 +113,7 @@ def main(argv=None):
             # Extract features
             pair_features = isoslam.extract_features_from_pair(pair)
             # DEBUGGING - Get information on features
-            if i_total_progress in (484):
+            if i_total_progress == 484:
                 print(f"{pair_features=}")
             # Temporary code sets up variables from the returned dictionary to match those currently used
             read1_start = pair_features["read1"]["start"]
@@ -312,7 +312,7 @@ def main(argv=None):
                     # if read 2 is the 1 assigned]
                     assignment = read2.get_tag("XT")
                     strand = strand_dict[assignment]
-
+            # TODO: Move logic to earlier in work flow and skip more preocessing if evaluate to False
             # assigned a "forward" and "reverse" read relative to the genome
             if read1.is_reverse and not read2.is_reverse:
                 reverse_read = read1


### PR DESCRIPTION
Adds the [todo-md](https://codeberg.org/lig/todo-md) pre-commit hook.

To test it added a `# TODO:` item to `all_introns_counts_and_info.py`, it extracted this and added it to the included `TODO.md`.