### PR TITLE
docs: Adds useful diagram and textual description of the workflow

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -70,3 +70,41 @@ develop/modify it using the [Mermaid Live Editor][mermaid-live] and make pull-re
 
 [mermaid]: https://mermaid.js.org/
 [mermaid-live]: https://mermaid.live
+
+## Descriptive Workflow
+
+<!-- markdownlint-disable MD033 -->
+<style>
+body {
+    counter-reset: h3counter;
+}
+h3 {
+    counter-increment: h3counter;
+}
+h3:before {
+    content: counter(h3counter) ". ";
+}
+</style>
+
+### Read alignments are loaded
+
+### The gene transcript these are within are identified
+
+### Introns within these genes are identified
+
+### Retain reads that are overlap with introns or splice ends
+
+```text
+                                                 Genome ----------------------->
+
+Read Alignment Blocks                     |>>>>|                     |>>>>>>>>>>>>>>>|
+Transcript 1:                      |===========|---------------------|=========|-------------------|==========|
+Transcript 2:              |====|------------------------------------|=========|-------------------|==========|
+
+Introns[0]                                      ---------------------
+Introns[1]                                                                      -------------------
+Introns[2]                       ------------------------------------
+Introns[3]                                                                      -------------------
+
+Exon : |========|   Read alignment block:  |>>>>>|
+```


### PR DESCRIPTION
Doesn't close #136 but I wanted to get started on the documentation and start building this up.  My one sentence
statements are likely way off the mark.

Feel free to expand on this either directly on this branch (`ns-rse/136-document-alignment`) or make a branch from it
and we can then merge it back in.

**NB** We have [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) implemented as a
[pre-commit](https://pre-commit.com). Could add this to virtual environment to lint code locally before commits
otherwise [pre-commit.ci](https://pre-commit.ci) will run on GitHub and fix what it can but there may be some that it
can't (e.g. it doesn't automatically fix hard-wrapping lines at 120 characters which is very useful for narrowing down
where there are changes).