### PR TITLE
docs: indent mkdocs options to API pages so they render

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore API files which require mkdocs options to be indented
+docs/api/*.md

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,9 +1,8 @@
 # IO Modules
 
 ::: isoslam.io
-handler: python
-options:
-docstring_style:
-numpy
-rendering:
-show_signature_annotations: true
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/isoslam.md
+++ b/docs/api/isoslam.md
@@ -3,9 +3,8 @@
 This module contains the main functions that constitute the IsoSLAM package.
 
 ::: isoslam.isoslam
-handler: python
-options:
-docstring_style:
-numpy
-rendering:
-show_signature_annotations: true
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -3,9 +3,8 @@
 This module handles logging setup.
 
 ::: isoslam.logging
-handler: python
-options:
-docstring_style:
-numpy
-rendering:
-show_signature_annotations: true
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/processing.md
+++ b/docs/api/processing.md
@@ -1,9 +1,8 @@
 # Processing
 
 ::: isoslam.processing
-handler: python
-options:
-docstring_style:
-numpy
-rendering:
-show_signature_annotations: true
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/summary.md
+++ b/docs/api/summary.md
@@ -1,9 +1,8 @@
 # Summary
 
 ::: isoslam.summary
-handler: python
-options:
-docstring_style:
-numpy
-rendering:
-show_signature_annotations: true
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -3,9 +3,8 @@
 This module contains various utilities used within the package.
 
 ::: isoslam.utils
-handler: python
-options:
-docstring_style:
-numpy
-rendering:
-show_signature_annotations: true
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true


### PR DESCRIPTION
Thanks to @tdjames1 for the pointer that these need indenting.

I think I did originally try that, but found that [prettier](https://prettier.io/docs/en/) which is one of the many
[pre-commit](https://pre-commit.com) hooks in place reformatted things and didn't pay sufficient attention.

This commit/pull-request includes a `.prettierignore` file to explicitly prevent that from happening.

Unsurprisingly the pages now look a _lot_ better.

Thanks @tdjames1 for letting me know about that :+1: