### PR TITLE
refactor: Move logic to skip processing to earlier in processing

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -16,7 +16,7 @@ globs:
 ignores:
   - "tmp/**/*.md"
   - "docs/api/**/*.md"
-  - TODO.md
+  - "TODO.md"
 
 # Fix any fixable errors
 fix: true

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,1 @@
-* [isoslam/all_introns_counts_and_info.py:232](isoslam/all_introns_counts_and_info.py#L232): Move logic to earlier in work flow and skip more pre-proocessing if evaluate to False
+* [isoslam/all_introns_counts_and_info.py:158](isoslam/all_introns_counts_and_info.py#L158): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,1 @@
-* [isoslam/all_introns_counts_and_info.py:158](isoslam/all_introns_counts_and_info.py#L158): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
 


### PR DESCRIPTION
Moves a lot of the logic that controls whether processing is undertake to earlier in the loop (thus avoiding some
unnecessary processing if we are to ultimately skip things).

At the same time I've taken the opportunity to (maybe) make the logic easier to understand and updated the comments with
explanations of what is being done.