### PR TITLE
refactor: Count conversions refactored

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,1 @@
 
-* [isoslam/all_introns_counts_and_info.py:150](isoslam/all_introns_counts_and_info.py#L150): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
-* [isoslam/all_introns_counts_and_info.py:48](isoslam/all_introns_counts_and_info.py#L48): Add option for locaing vcf file

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,3 @@
 
+* [isoslam/all_introns_counts_and_info.py:150](isoslam/all_introns_counts_and_info.py#L150): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
+* [isoslam/all_introns_counts_and_info.py:48](isoslam/all_introns_counts_and_info.py#L48): Add option for locaing vcf file

--- a/isoslam/default_config.yaml
+++ b/isoslam/default_config.yaml
@@ -5,6 +5,12 @@ bam_file: data/bam/.bam
 gtf_file: data/gtf/
 bed_file: data/bed/
 vcf_file: data/vcf/
+forward_reads:
+  from: "T"
+  to: "C"
+reverse_reads:
+  from: "A"
+  to: "G"
 summary_counts:
   file_pattern: "**/*.tsv"
   separator: "\t"

--- a/isoslam/isoslam.py
+++ b/isoslam/isoslam.py
@@ -306,7 +306,7 @@ def unique_conversions(
     """
     flat1 = [(key, nested_list) for key, values in reads1.items() for nested_list in values]
     flat2 = [(key, nested_list) for key, values in reads2.items() for nested_list in values]
-    logger.info("Extracted unique conversions in both reads, combining to unique set.")
+    # logger.debug("Extracted unique conversions in both reads, combining to unique set.")
     return frozenset(flat1 + flat2)  # type: ignore[arg-type]
 
 
@@ -331,7 +331,7 @@ def remove_common_reads(retained: set[list[Any]], spliced: set[list[Any]]) -> tu
     common = retained & spliced
     retained -= common
     spliced -= common
-    logger.info("Removed common elements from retained and spliced.")
+    # logger.debug("Removed common elements from retained and spliced.")
     return (retained, spliced)
 
 
@@ -392,7 +392,7 @@ def conversions_per_read(  # pylint: disable=too-many-positional-arguments
                     converted_position.add(genome_position)
             else:
                 converted_position.add(genome_position)
-    logger.debug(f"convertible : {convertible}\nconverted_position : {converted_position}\ncoverage : {coverage}")
+    # logger.debug(f"convertible : {convertible}\nconverted_position : {converted_position}\ncoverage : {coverage}")
     return (convertible, converted_position, coverage)
 
 
@@ -455,5 +455,5 @@ def count_conversions_across_pairs(
         coverage,
         vcf_file,
     )
-    logger.info("Counted conversions paired reads")
+    # logger.debug("Counted conversions paired reads")
     return {"convertible": len(convertible), "converted_position": len(converted_position), "coverage": len(coverage)}

--- a/isoslam/isoslam.py
+++ b/isoslam/isoslam.py
@@ -306,6 +306,7 @@ def unique_conversions(
     """
     flat1 = [(key, nested_list) for key, values in reads1.items() for nested_list in values]
     flat2 = [(key, nested_list) for key, values in reads2.items() for nested_list in values]
+    logger.info("Extracted unique conversions in both reads, combining to unique set.")
     return frozenset(flat1 + flat2)  # type: ignore[arg-type]
 
 
@@ -330,6 +331,7 @@ def remove_common_reads(retained: set[list[Any]], spliced: set[list[Any]]) -> tu
     common = retained & spliced
     retained -= common
     spliced -= common
+    logger.info("Removed common elements from retained and spliced.")
     return (retained, spliced)
 
 
@@ -372,7 +374,6 @@ def conversions_per_read(  # pylint: disable=too-many-positional-arguments
     # Ensure we have upper case conversions to compare
     conversion_from = conversion_from.upper()
     conversion_to = conversion_to.upper()
-    print(f"{vcf_file=}")
     for read_position, genome_position, genome_sequence in read.get_aligned_pairs(with_seq=True):
         if None in (read_position, genome_position, genome_sequence):
             continue
@@ -391,4 +392,68 @@ def conversions_per_read(  # pylint: disable=too-many-positional-arguments
                     converted_position.add(genome_position)
             else:
                 converted_position.add(genome_position)
+    logger.debug(f"convertible : {convertible}\nconverted_position : {converted_position}\ncoverage : {coverage}")
     return (convertible, converted_position, coverage)
+
+
+def count_conversions_across_pairs(
+    forward_read: dict[str, dict[str, Any]],
+    reverse_read: dict[str, dict[str, Any]],
+    vcf_file: VariantFile,
+    forward_conversion: dict[str, str] | None = None,
+    reverse_conversion: dict[str, str] | None = None,
+) -> dict[str, int]:
+    """
+    Count conversions across paired reads.
+
+    Parameters
+    ----------
+    forward_read : dict[str, dict[str, Any]]
+        Aligned segment for forward read.
+    reverse_read : dict[str, dict[str, Any]]
+        Aligned segment for reversed read.
+    vcf_file : VariantFile
+        Variant File.
+    forward_conversion : dict, optional
+        Forward conversion dictionary typically ''{"from": "A", "to": "G"}''.
+    reverse_conversion : dict, optional
+        Reverse conversion, typically ''{"from": "T", "to": "C"}''.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        Tuple of the number of convertible base pairs, the number of conversions and the coverage of the paired
+      alignments.
+
+    Raises
+    ------
+    ValueError
+        ValueError is raised if either ''forward_conversion'' or ''reverse_conversion'' is ''None''.
+    """
+    if forward_conversion is None:
+        raise ValueError("forward_conversion can not be empty.")
+    if reverse_conversion is None:
+        raise ValueError("reverse_conversion can not be empty.")
+
+    # Count conversions on the forward read
+    convertible, converted_position, coverage = conversions_per_read(
+        forward_read,
+        forward_conversion["from"],
+        forward_conversion["to"],
+        convertible=set(),
+        converted_position=set(),
+        coverage=set(),
+        vcf_file=vcf_file,
+    )
+    # Count conversions on the reverse read
+    convertible, converted_position, coverage = conversions_per_read(
+        reverse_read,
+        reverse_conversion["from"],
+        reverse_conversion["to"],
+        convertible,
+        converted_position,
+        coverage,
+        vcf_file,
+    )
+    logger.info("Counted conversions paired reads")
+    return {"convertible": len(convertible), "converted_position": len(converted_position), "coverage": len(coverage)}

--- a/isoslam/isoslam.py
+++ b/isoslam/isoslam.py
@@ -123,6 +123,10 @@ def extract_features_from_read(read: AlignedSegment) -> dict[str, int | str | No
         transcript = read.get_tag("XT")
     except KeyError:
         transcript = None
+    try:
+        reverse = read.is_reverse
+    except KeyError:
+        reverse = None
     return {
         "start": read.reference_start,
         "end": read.reference_end,
@@ -131,6 +135,7 @@ def extract_features_from_read(read: AlignedSegment) -> dict[str, int | str | No
         "transcript": transcript,
         "block_start": block_start,
         "block_end": block_end,
+        "reverse": reverse,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pysam
 import pytest
-from pysam import AlignedSegment, AlignmentFile
+from pysam import AlignedSegment, AlignmentFile, VariantFile
 
 from isoslam import io, isoslam
 
@@ -34,7 +34,7 @@ def bam_file2() -> AlignmentFile:
 
 
 @pytest.fixture()
-def bam_unaligned_file1() -> AlignmentFile:
+def bam_no4sU() -> AlignmentFile:
     """Load an unsorted and unassigned ``.bam`` file (ignore the filename!)."""
     return io.load_file(BAM_DIR / "d0_no4sU_filtered_remapped_sorted.bam")
 
@@ -49,6 +49,12 @@ def gtf_file() -> pysam.tabix_generic_iterator:
 def bed_file() -> dict:
     """Load a ``.gtf`` file."""
     return io.load_file(BED_DIR / "test_coding_introns.bed")
+
+
+@pytest.fixture()
+def vcf_file() -> VariantFile:
+    """Load a ``.vcf`` file."""
+    return io.load_file(VCF_DIR / "d0.vcf.gz")
 
 
 @pytest.fixture()
@@ -70,24 +76,24 @@ def default_config() -> dict[str:Any]:
 
 
 @pytest.fixture()
-def aligned_segment_unassigned_28584(bam_unaligned_file1: AlignmentFile) -> AlignedSegment:
+def aligned_segment_unassigned_28584(bam_no4sU: AlignmentFile) -> AlignedSegment:
     """Extract an individual AlignedSegment from a ``.bam`` file."""
     # NB : .fetch() returns AlignedSegments that span the start and end region, not just those within
-    return next(bam_unaligned_file1.fetch(contig="chr9", start=28592, end=28593))
+    return next(bam_no4sU.fetch(contig="chr9", start=28592, end=28593))
 
 
 @pytest.fixture()
-def aligned_segment_unassigned_17416(bam_unaligned_file1: AlignmentFile) -> AlignedSegment:
+def aligned_segment_unassigned_17416(bam_no4sU: AlignmentFile) -> AlignedSegment:
     """Extract an individual AlignedSegment from a ``.bam`` file."""
     # NB : .fetch() returns AlignedSegments that span the start and end region, not just those within
-    return next(bam_unaligned_file1.fetch(contig="chr9", start=17804, end=18126))
+    return next(bam_no4sU.fetch(contig="chr9", start=17804, end=18126))
 
 
 @pytest.fixture()
-def aligned_segment_unassigned_18029(bam_unaligned_file1: AlignmentFile) -> AlignedSegment:
+def aligned_segment_unassigned_18029(bam_no4sU: AlignmentFile) -> AlignedSegment:
     """Extract an individual AlignedSegment from a ``.bam`` file."""
     # NB : .fetch() returns AlignedSegments that span the start and end region, not just those within
-    return next(bam_unaligned_file1.fetch(contig="chr9", start=18156, end=24870))
+    return next(bam_no4sU.fetch(contig="chr9", start=18156, end=24870))
 
 
 @pytest.fixture()

--- a/tests/test_all_introns_counts_and_info.py
+++ b/tests/test_all_introns_counts_and_info.py
@@ -36,6 +36,7 @@ def test_main(file_path: Path, tmp_path: Path, regtest) -> None:
         utron_bed=list(BED_DIR.glob("*.bed"))[0],
         vcf_path=list(VCF_DIR.glob("*.vcf.gz"))[0],
         outfile_tsv=str(tmp_path / "test.tsv"),
+        config_file=None,
     )
     results = all_introns_counts_and_info.main(argv=args)
     # Ideally would like to use syrupy to test snapshots but pd.DataFrame() are not yet supported

--- a/tests/test_isoslam.py
+++ b/tests/test_isoslam.py
@@ -95,7 +95,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
 
 
 @pytest.mark.parametrize(
-    ("aligned_segment", "start", "end", "length", "status", "transcript", "block_start", "block_end"),
+    ("aligned_segment", "start", "end", "length", "status", "transcript", "block_start", "block_end", "reverse"),
     [
         pytest.param(  # type: ignore[misc]
             "aligned_segment_unassigned_28584",
@@ -106,6 +106,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             None,
             (28584, 28704),
             (28704, 28733),
+            True,
             id="28584 - Assignment and Transcript are None",
         ),
         pytest.param(
@@ -117,6 +118,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             None,
             (17416, 17718),
             (17479, 17805),
+            False,
             id="17416 - Assignment and Transcript are None",
         ),
         pytest.param(
@@ -128,6 +130,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             None,
             (18029, 18380),
             (18174, 18385),
+            True,
             id="18029 - Assignment and Transcript are None",
         ),
         pytest.param(
@@ -139,6 +142,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "MSTRG.63147",
             (17814, 18027),
             (17855, 18136),
+            True,
             id="17814 - Assigned to MSTRG.63147",
         ),
         pytest.param(
@@ -150,6 +154,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "MSTRG.63147",
             (14770,),
             (14876,),
+            False,
             id="14770 - Assigned to MSTRG.63147",
         ),
         pytest.param(
@@ -161,6 +166,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             "MSTRG.63147",
             (15967,),
             (16117,),
+            False,
             id="15967 - Assigned to MSTRG.63147",
         ),
         pytest.param(
@@ -172,6 +178,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             None,
             (21051,),
             (21201,),
+            True,
             id="21051 - Unassigned",
         ),
         pytest.param(
@@ -183,6 +190,7 @@ def test_extract_segment_pairs(bam_file: str | Path, expected_length: int) -> No
             None,
             (20906,),
             (21056,),
+            False,
             id="20906 - Unassigned",
         ),
     ],
@@ -196,11 +204,11 @@ def test_extract_features_from_read(
     transcript: str,
     block_start: tuple[int, int],
     block_end: tuple[int, int],
+    reverse: bool,
     request: pytest.FixtureRequest,
 ) -> None:
     """Test extract of features from an unassigned and assigned segment reads."""
     segment = isoslam.extract_features_from_read(request.getfixturevalue(aligned_segment))
-    print(f"{segment=}")
     assert isinstance(segment, dict)
     assert segment["start"] == start
     assert segment["end"] == end
@@ -209,6 +217,7 @@ def test_extract_features_from_read(
     assert segment["transcript"] == transcript
     assert segment["block_start"] == block_start
     assert segment["block_end"] == block_end
+    assert segment["reverse"] == reverse
 
 
 @pytest.mark.parametrize(
@@ -226,6 +235,7 @@ def test_extract_features_from_read(
                     "transcript": "MSTRG.63147",
                     "block_start": (17814, 18027),
                     "block_end": (17855, 18136),
+                    "reverse": True,
                 },
                 "read2": {
                     "start": 14770,
@@ -235,6 +245,7 @@ def test_extract_features_from_read(
                     "transcript": "MSTRG.63147",
                     "block_start": (14770,),
                     "block_end": (14876,),
+                    "reverse": False,
                 },
             },
             id="28584 and 17416 - Assigned and transcript MSTRG.63147",
@@ -251,6 +262,7 @@ def test_extract_features_from_read(
                     "transcript": None,
                     "block_start": (21051,),
                     "block_end": (21201,),
+                    "reverse": True,
                 },
                 "read2": {
                     "start": 20906,
@@ -260,6 +272,7 @@ def test_extract_features_from_read(
                     "transcript": None,
                     "block_start": (20906,),
                     "block_end": (21056,),
+                    "reverse": False,
                 },
             },
             id="21051 and 21056 - Assignment and Transcript are None",


### PR DESCRIPTION
Closes #144
Closes #145

Refactors duplicated for loops into two functions and replaces these as the functionality within the existing workflow
`all_introns_counts_and_info.py`.

- `conversions_per_read()` counts the number of conversions for a single read.
- `count_conversions_across_pairs()` calls this twice with different reads, whether strands are `+`/`-` determines which
  way round these are passed.
- Adds some values to the configuration files for `forward` and `reverse` conversions so that this is configurable
  should it ever be required.
- Logic for assigning reads to forward/reverse is moved to earlier in processin (this will in due course be more
  thoroughly refactored throughout)


Can likely be improved upon to some extent by having `count_conversions_across_pairs()` accept the pair of reads and
work out which way round they should be checked for conversions, but would prefer to get forward/reverse assignments
sorted first as this will make it easier.