### PR TITLE
refactor: Function for writing results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,9 @@ cython_debug/
 *~
 .dir-locals.el
 
+# direnv
+.envrc
+
 # pytest-testmon
 .testmon*
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ If you wish to contribute fixes or features yourself you can find detailed infor
 Please use the [Citation File Format](https://citation-file-format.github.io/) which is available in this repository. A
 BibTex or APA formatted citation can be easily accessed from the "_Cite this repository_" link on the right hand side.
 
-[contributing]: https://sudlab.github.io/IsoSLAM/contributing
 [isoslam_issue]: https://github.com/sudlab/IsoSLAM/issues/new/choose
 [isoslam_bug]: https://github.com/sudlab/IsoSLAM/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&title=%5BBug%5D%3A+
 [isoslam_feature]: https://github.com/sudlab/IsoSLAM/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yaml&title=%5Bfeature%5D+%3A+

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,4 @@
 
+* [isoslam/all_introns_counts_and_info.py:154](isoslam/all_introns_counts_and_info.py#L154): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
+* [isoslam/all_introns_counts_and_info.py:49](isoslam/all_introns_counts_and_info.py#L49): Add option for locating vcf file
+* [isoslam/all_introns_counts_and_info.py:97](isoslam/all_introns_counts_and_info.py#L97): Lowercase and 'chromosome' over 'Chr'

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,1 @@
 
-* [isoslam/all_introns_counts_and_info.py:154](isoslam/all_introns_counts_and_info.py#L154): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
-* [isoslam/all_introns_counts_and_info.py:49](isoslam/all_introns_counts_and_info.py#L49): Add option for locating vcf file
-* [isoslam/all_introns_counts_and_info.py:97](isoslam/all_introns_counts_and_info.py#L97): Lowercase and 'chromosome' over 'Chr'

--- a/isoslam/default_config.yaml
+++ b/isoslam/default_config.yaml
@@ -11,6 +11,8 @@ forward_reads:
 reverse_reads:
   from: "A"
   to: "G"
+delim: "\t"
+output_ext: ".tsv"
 summary_counts:
   file_pattern: "**/*.tsv"
   separator: "\t"

--- a/isoslam/io.py
+++ b/isoslam/io.py
@@ -5,6 +5,7 @@ import gzip
 from collections.abc import Callable, Generator
 from datetime import datetime
 from importlib import resources
+from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -401,3 +402,42 @@ def data_frame_to_file(
     outdir_file = Path(output_dir) / f"{outfile}"
     data.to_csv(outdir_file, sep=sep, **kwargs)
     logger.debug(f"File written to : {outdir_file}")
+
+
+def write_assigned_conversions(  # pylint: disable=too-many-positional-arguments
+    assigned_conversions: set[list[Any]],
+    coverage_counts: dict[str, int],
+    read_uid: int,
+    assignment: str,
+    outfile: TextIOWrapper,
+    delim: str,
+) -> None:
+    r"""
+    Write assigned conversions to files.
+
+    Combines the ''coverage_counts'' with the ''assigned_conversions'' and outputs to disk at the specified location and
+    filename with configurable delimiter.
+
+    Parameters
+    ----------
+    assigned_conversions : set[list[Any]]
+        A set of assigned conversions. Each element of the set is a list of key features (CHECK WHAT THESE ARE).
+    coverage_counts : dict[str, int] dest_dir: str | Path
+        A dictionary of coverage counts indexed by CHECK.
+    read_uid : int
+        Integer representing the unique read ID.
+    assignment : str
+        Type of assignment, either ''Rep'' or ''Spl'' (for Splice).
+    outfile : Any
+        Open connection to write results to.
+    delim : str
+        Delimiter to be used between fields, typically '','' for ''.csv'' or ''\t'' for ''.tsv'' output.
+    """
+    for transcript_id, position in assigned_conversions:
+        start, end, chromosome, strand = position
+        outfile.write(
+            f"{read_uid}{delim}{transcript_id}{delim}"
+            f"{start}{delim}{end}{delim}{chromosome}{delim}"
+            f"{strand}{delim}{assignment}{delim}{coverage_counts['converted_position']}{delim}"
+            f"{coverage_counts['convertible']}{delim}{coverage_counts['coverage']}\n"
+        )

--- a/tests/test_all_introns_counts_and_info.py
+++ b/tests/test_all_introns_counts_and_info.py
@@ -36,6 +36,7 @@ def test_main(file_path: Path, tmp_path: Path, regtest) -> None:
         utron_bed=list(BED_DIR.glob("*.bed"))[0],
         vcf_path=list(VCF_DIR.glob("*.vcf.gz"))[0],
         outfile_tsv=str(tmp_path / "test.tsv"),
+        delim="\t",
         config_file=None,
     )
     results = all_introns_counts_and_info.main(argv=args)


### PR DESCRIPTION
Closes #147

Breaks out the duplicated code that writes results to disk to its own function with tests.

I think longer term we may want to see if there are alternatives to having a file connection open and performing
operations within and writing to disk but I will need to see how this plays out with RAM when working with larger
datasets.

- Ignore `.envrc` (a file @ns-rse is using to leverage [direnvs](https://direnv.net/))
- Tidy up some linting in `all_introns_counts_and_info.py`
- Smattering of `TODO` items collated into `TODO.md` for @ns-rse future reference