### PR TITLE
bug: correct writing of retained/spliced

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,4 @@
 
+* [isoslam/all_introns_counts_and_info.py:154](isoslam/all_introns_counts_and_info.py#L154): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
+* [isoslam/all_introns_counts_and_info.py:49](isoslam/all_introns_counts_and_info.py#L49): Add option for locating vcf file
+* [isoslam/all_introns_counts_and_info.py:97](isoslam/all_introns_counts_and_info.py#L97): Lowercase and 'chromosome' over 'Chr'

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,1 @@
 
-* [isoslam/all_introns_counts_and_info.py:154](isoslam/all_introns_counts_and_info.py#L154): Extract is_reverse to the pair_features["read1"]["reverse"] in refactored code
-* [isoslam/all_introns_counts_and_info.py:49](isoslam/all_introns_counts_and_info.py#L49): Add option for locating vcf file
-* [isoslam/all_introns_counts_and_info.py:97](isoslam/all_introns_counts_and_info.py#L97): Lowercase and 'chromosome' over 'Chr'

--- a/isoslam/all_introns_counts_and_info.py
+++ b/isoslam/all_introns_counts_and_info.py
@@ -281,7 +281,7 @@ def main(argv=None):
                 )
                 results = pd.concat([results, row])
             io.write_assigned_conversions(
-                assigned_conversions=assign_conversions_to_spliced,
+                assigned_conversions=assign_conversions_to_retained,
                 coverage_counts=coverage_counts,
                 read_uid=i_output,
                 assignment="Ret",
@@ -289,7 +289,7 @@ def main(argv=None):
                 delim=argv_as_dictionary["delim"],
             )
             io.write_assigned_conversions(
-                assigned_conversions=assign_conversions_to_retained,
+                assigned_conversions=assign_conversions_to_spliced,
                 coverage_counts=coverage_counts,
                 read_uid=i_output,
                 assignment="Spl",


### PR DESCRIPTION
Passed these in the wrong way round/with the wrong `assignment` correcting that..

Tests still passed as they were based on the `pd.DataFrame` that were added for the regression and addressing those is
being done on a separate branch (where I spotted this error).