### PR TITLE
docs: Starts documenting usage of the tools

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,58 @@ Ideally you should install IsoSLAM under a Python Virtual Environment. Details o
 beyond the scope of this documentation but some advice can be found in the
 [contributing](contributing/index.md#virtual-environments) section.
 
+## IsoSLAM
+
+### GitHub
+
+There are two methods of installing IsoSLAM from its [GitHub repository][isoslam].
+
+#### Cloning
+
+You can clone the repository and install from the clone.
+
+```bash
+git clone git@github.com:sudlab/IsoSLAM.git
+cd IsoSLAM
+pip install -e .
+```
+
+By using the `-e` (editable) flag it means you can switch branches.
+
+#### `pip` from GitHub
+
+The package installer for Python [pip][pip] can be used to install packages directly from their version control
+homepage.
+
+```bash
+pip install git+ssh://git@github.com/IsoSLAM
+```
+
+If you want to install a specific branch or commit you can do so.
+
+```bash
+pip install git+ssh://git@github.com/IsoSLAM@<branch-name>
+pip install git+ssh://git@github.com/IsoSLAM@<commit-hash>
+```
+
+### PyPI
+
+We intend to publish IsoSLAM to the [Python Package Index (PyPI)][pypi]. When available you will be able to install with
+
+```bash
+pip install IsoSLAM
+```
+
+**NB** IsoSLAM is **NOT** currently available on PyPI.
+
+### Bioconda
+
+**NB** IsoSLAM is **NOT** currently available on Bioconda.
+
 ## Dependencies
 
-There are a number of external dependencies required for running IsoSLAM.
+There are a number of external dependencies required for running IsoSLAM as part of a [ruffus][ruffus] pipeline, which
+is typically essential to prepare the files for processing.
 
 - `samtools` / `bcftools` are both required and can be downloaded from [htslib][htslib]
 - [VarScan][varscan] ([documentation][varscan_docs])
@@ -150,48 +199,6 @@ mamba install -c conda-forge -c bioconda subread
 mamba install -c conda-forge -c bioconda varscan
 ```
 
-## GitHub
-
-There are two methods of installing IsoSLAM from its [GitHub repository][isoslam].
-
-### Cloning
-
-You can clone the repository and install from the clone.
-
-```bash
-git clone git@github.com:sudlab/IsoSLAM.git
-cd IsoSLAM
-pip install -e .
-```
-
-By using the `-e` (editable) flag it means you can switch branches.
-
-### `pip` from GitHub
-
-The package installer for Python [pip][pip] can be used to install packages directly from their version control
-homepage.
-
-```bash
-pip install git+ssh://git@github.com/IsoSLAM
-```
-
-If you want to install a specific branch or commit you can do so.
-
-```bash
-pip install git+ssh://git@github.com/IsoSLAM@<branch-name>
-pip install git+ssh://git@github.com/IsoSLAM@<commit-hash>
-```
-
-## PyPI
-
-We intend to publish IsoSLAM to the [Python Package Index (PyPI)][pypi]. When available you will be able to install with
-
-```bash
-pip install IsoSLAM
-```
-
-**NB** IsoSLAM is **NOT** currently available on PyPI.
-
 [arch]: https://archlinux.org/
 [aur]: https://aur.archlinux.org/
 [bedtools]: https://bedtools.readthedocs.io/en/latest/
@@ -200,6 +207,7 @@ pip install IsoSLAM
 [isoslam]: https://github.com/sudlab/IsoSLAM
 [pip]: https://pip.pypa.io/en/stable/
 [pypi]: https://pypi.org/
+[ruffus]: http://www.ruffus.org.uk/
 [subread]: https://github.com/ShiLab-Bioinformatics/subread
 [subread_docs]: https://subread.sourceforge.net/
 [varscan]: https://github.com/dkoboldt/varscan

--- a/docs/links.md
+++ b/docs/links.md
@@ -1,0 +1,18 @@
+# Links
+
+Links to software, documentation and related topics.
+
+- [Bedtools][bedtools]
+- [CGAT][cgat]
+- [htslib][htslib]
+- [Ruffus][ruffus]
+- [varscan][varscan_docs] (GitHub : [varscan][varscan])
+
+## Related Software
+
+[bedtools]: https://bedtools.readthedocs.io/en/latest/
+[cgat]: https://cgat-developers.github.io/cgat-core/
+[htslib]: https://www.htslib.org/
+[ruffus]: http://www.ruffus.org.uk/
+[varscan]: https://github.com/dkoboldt/varscan
+[varscan_docs]: https://dkoboldt.github.io/varscan/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,139 @@
 # Usage
 
-**TO BE WRITTEN** Awaiting refactoring of code base.
+## Stand alone usage
+
+Once installed the `isolsam` command is should be available and you can view the options and sub-commands with
+
+```shell
+❱ isoslam --help
+
+usage: isoslam [-h] [-v] [-c CONFIG_FILE] [-b BASE_DIR] [-o OUTPUT_DIR] [-l LOG_LEVEL] {process,create-config,summary-counts} ...
+
+Run various programs related to IsoSLAM. Add the name of the program you wish to run.
+
+options:
+  -h, --help            show this help message and exit
+  -v, --version         Report the installed version of IsoSLAM.
+  -c, --config-file CONFIG_FILE
+                        Path to a YAML configuration file.
+  -b, --base-dir BASE_DIR
+                        Base directory to run isoslam on.
+  -o, --output-dir OUTPUT_DIR
+                        Output directory to write results to.
+  -l, --log-level LOG_LEVEL
+                        Logging level to use, default is 'info' for verbose output use 'debug'.
+
+program:
+  Available programs listed below:
+
+  {process,create-config,summary-counts}
+    process             Process all files and run all summary plotting and statistics.
+    create-config       Create a configuration file using the defaults.
+    summary-counts      Summarise the counts.
+```
+
+Global options that set the configuration file to use, the base and output directory and log-level can be
+specified. Users then have a number of programs from IsoSLAM.
+
+- `process`
+- `create-config`
+- `summary-counts`
+
+### Processing
+
+Help is available on using the `isoslam process` command and can be viewed with the `--help` option.
+
+```shell
+❱ isoslam process --help
+usage: isoslam process [-h] [-b BAM_FILE] [-g GTF_FILE] [-d BED_FILE] [-v VCF_FILE] [-u UPPER_PAIRS_LIMIT] [-f FIRST_MATCHED_LIMIT] [--delim DELIM]
+                       [--output-file OUTPUT_FILE]
+
+Process all files and run all summary plotting and statistics.
+
+options:
+  -h, --help            show this help message and exit
+  -b, --bam-file BAM_FILE
+                        Path to '.bam' file that has undergone read assignment with 'featureCount'.
+  -g, --gtf-file GTF_FILE
+                        Path to '.gtf' transcript assembly file.
+  -d, --bed-file BED_FILE
+                        Path to '.bed' utron file. Must be bed6 format.
+  -v, --vcf-file VCF_FILE
+                        Path to '.vcf.gz' file.
+  -u, --upper-pairs-limit UPPER_PAIRS_LIMIT
+                        Upper limit of pairs to be processed.
+  -f, --first-matched-limit FIRST_MATCHED_LIMIT
+                        Limit of matches.
+  --delim DELIM         Delimiter to use in output.
+  --output-file OUTPUT_FILE
+                        File to write results to.
+```
+
+It is important to remember that the `.bam` file requires pre-processing and instructions on how to do that can be found
+below.
+
+Three additional input files are required.
+
+- `.gtf` : DESCRIPTION
+- `.bed` : DESCRIPTION
+- `.vcf` : DESCRIPTION
+
+By default output is written to the `./output` directory which will be created if it does not exist and the default
+output file is `results.parquet` which is in [Parquet][parquet] format. The output directory is configurable, as is the
+output file name. If you would rather your output is saved as ASCII delimited file it is easy to do so by specifying the
+`--delim ,` (for comma-delimited) or `--delim \t` (for tab-delimited) and using the appropriate file extension in the
+`--output-file`. For example the following outputs to `new_results` directory in a file `output_20250213.csv`
+
+```shell
+❱ isoslam --output-dir new_results process \
+         --bam-file d0_no4sU_EKRN230046545-1A_HFWGNDSX7_L4.star.bam \
+         --gtf-file test_wash1.gtf \
+         --bed-file test_coding_introns.bed \
+         --vcf-file d0.vcf.gz \
+         --delim "," \
+         --output-file output_20250213.csv
+```
+
+### Configuration File
+
+It is possible to place all configuration options in a [YAML][yaml] configuration file. A sample configuration file can
+be generated using the `isoslam create-config` command and there are options to specify the output filename, the default
+is `config.yaml` in the current directory (see `isoslam create-config --help` for all options).
+
+```shell
+❱ isoslam create-config --help
+usage: isoslam create-config [-h] [-f FILENAME] [-o OUTPUT_DIR]
+
+Create a configuration file using the defaults.
+
+options:
+  -h, --help            show this help message and exit
+  -f, --filename FILENAME
+                        Name of YAML file to save configuration to (default 'config.yaml').
+  -o, --output-dir OUTPUT_DIR
+                        Path to where the YAML file should be saved (default './' the current directory).
+```
+
+Once created you can edit the `config.yaml` to specify all fields and parameters and then invoke processing using this
+file.
+
+```shell
+❱ isoslam --config-file config.yaml process
+```
+
+Any command line options given such as the `--upper-pairs-limit` or `--first-matched-limit` will override those details
+in the custom `config.yaml`. This means it is particularly useful for usage in the full pipeline as `.gtf`, `.bed` and
+`.vcf` files are often common and it is the `.bam` input file that changes between runs. Thus you can specify the common
+files in your configuration file and then use the `--bam-file <file_path>` to override the field in the configuration
+file.
+
+## Ruffus/CGAT pipeline
+
+Typically `isoslam` is part of a workflow pipeline that processes a large number of files. As such [ruffus][ruffus] is
+used to keep track of tasks.
+
+EXPAND THIS SECTION WITH WORKED EXAMPLES BASED ON EXISTING SCRIPTS.
+
+[parquet]: https://parquet.apache.org/docs/file-format/
+[ruffus]: http://www.ruffus.org.uk/
+[yaml]: https://yaml.org/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Processing: api/processing.md
       - Summary: api/summary.md
       - Utils: api/utils.md
+  - Links: links.md
 
 extra:
   version:


### PR DESCRIPTION
Partially address #158

- Simple examples of stand-alone usage are described.
- Restructure of installation instructions
- adds a Links page

Held back on adding the recent new R releases for related work from the links page...

- [EZbakR](https://isaacvock.github.io/EZbakR/)
- [fast12EZbakR](https://fastq2ezbakr.readthedocs.io/en/latest/)