### PR TITLE
feature(validation): Adds module/function w/tests to validate config

### DIFF
--- a/isoslam/processing.py
+++ b/isoslam/processing.py
@@ -8,7 +8,7 @@ from typing import Any
 import polars as pl
 from loguru import logger
 
-from isoslam import __version__, io, isoslam, logging, summary
+from isoslam import __version__, io, isoslam, logging, summary, validation
 
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-branches
@@ -229,6 +229,7 @@ def process(
         logging.setup(level=vars(args)["log_level"])
     else:
         logging.setup(level=config["log_level"])
+    validation.validate_config(config=config, schema=validation.DEFAULT_CONFIG_SCHEMA, config_type="configuration")
 
     # Load files...
     vcffile = io.load_file(config["vcf_file"])

--- a/isoslam/validation.py
+++ b/isoslam/validation.py
@@ -1,0 +1,112 @@
+"""Validation of configuration."""
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from schema import Or, Schema, SchemaError
+
+# pylint: disable=eval-used
+
+
+def validate_config(config: dict[str, Any], schema: Schema, config_type: str) -> None:
+    """
+    Validate configuration.
+
+    Parameters
+    ----------
+    config : dict
+        Config dictionary imported by read_yaml() and parsed through clean_config().
+    schema : Schema
+        A schema against which the configuration is to be compared.
+    config_type : str
+        Description of configuration being validated.
+    """
+    print(f"{config=}")
+    try:
+        schema.validate(config)
+        logger.info(f"The {config_type} is valid.")
+    except SchemaError as schema_error:
+        raise SchemaError(
+            f"There is an error in your {config_type} configuration. "
+            "Please refer to the first error message above for details"
+        ) from schema_error
+
+
+DEFAULT_CONFIG_SCHEMA = Schema(
+    {
+        "log_level": Or(
+            "debug",
+            "info",
+            "warning",
+            "error",
+            error="Invalid value in config for 'log_level', valid values are"
+            "'info' (default), 'debug', 'error' or 'warning",
+        ),
+        "output_dir": Path,
+        "output_file": Or(str, error="Invalid value in config for output_file, should be 'str'"),
+        "bam_file": Path,
+        "gtf_file": Path,
+        "bed_file": Path,
+        "vcf_file": Path,
+        "upper_pairs_limit": Or(int, error="Invalid value in config for upper_pairs_limit should be 'int'"),
+        "first_matched_limit": Or(int, error="Invalid value in config for first_matched_limit should be 'int'"),
+        "forward_reads": {
+            "from": Or(
+                "A",
+                "C",
+                "T",
+                "G",
+                error="Invalid value in config for forward_reads.from, should be 'A', 'C', 'G' or 'T'",
+            ),
+            "to": Or(
+                "A", "C", "T", "G", error="Invalid value in config for forward_reads.to, should be 'A', 'C', 'G' or 'T'"
+            ),
+        },
+        "reverse_reads": {
+            "from": Or(
+                "A",
+                "C",
+                "T",
+                "G",
+                error="Invalid value in config for reverse_reads.from, should be 'A', 'C', 'G' or 'T'",
+            ),
+            "to": Or(
+                "A", "C", "T", "G", error="Invalid value in config for reverse_reads.to, should be 'A', 'C', 'G' or 'T'"
+            ),
+        },
+        "delim": Or("\t", ",", ";", error="Invalid value in config for delim, should be '\t', ',' or ';'"),
+        "schema": {
+            # Whilst strings in default_config.yaml they are updated to the appropriate type on loading
+            "read_uid": Or(type(eval("int")), error="Invalid value in config for schema.read_uid, should be 'int'"),
+            "transcript_id": Or(
+                type(eval("str")), error="Invalid value in config for schema.transcript_id, should be 'str'"
+            ),
+            "start": Or(type(eval("int")), error="Invalid value in config for schema.read_uid, should be 'int'"),
+            "end": Or(type(eval("int")), error="Invalid value in config for schema.read_uid, should be 'int'"),
+            "chr": Or(type(eval("str")), error="Invalid value in config for schema.transcript_id, should be 'str'"),
+            "strand": Or(type(eval("str")), error="Invalid value in config for schema.strand, should be 'str'"),
+            "assignment": Or(type(eval("str")), error="Invalid value in config for schema.assignment, should be 'str'"),
+            "conversions": Or(
+                type(eval("int")), error="Invalid value in config for schema.conversions, should be 'int'"
+            ),
+            "convertible": Or(
+                type(eval("int")), error="Invalid value in config for schema.convertible, should be 'int'"
+            ),
+            "coverage": Or(type(eval("int")), error="Invalid value in config for schema.coverage, should be 'int'"),
+        },
+        "summary_counts": {
+            "file_pattern": Or(
+                str, error="Invalid value in config for summary_counts.file_pattern, should be str/glob"
+            ),
+            "separator": Or("\t", ",", ";", error="Invalid value in config for delim, should be '\t', ',' or ';'"),
+            "groupby": Or([str], error="Invalid value in config for summary_counts.groupby, should be list of str"),
+            "output": {
+                "outfile": Or(str, error="Invalid value in config for summary_counts.output.outfile, should be str"),
+                "sep": Or("\t", ",", ";", error="Invalid value in config for delim, should be '\t', ',' or ';'"),
+                "index": bool,
+            },
+        },
+        "plot": bool,
+    }
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "polars",
   "pysam",
   "ruamel.yaml",
+  "schema",
   "sqlalchemy",
 ]
 
@@ -194,6 +195,7 @@ lint.ignore = [
   "B905",
   "E501",
   "S101",
+  "S307",
   "S403",
 ]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
@@ -282,6 +284,7 @@ module = [
   "polars",
   "pysam",
   "ruamel.yaml",
+  "schema",
 ]
 ignore_missing_imports = true
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -195,20 +195,24 @@ def test_entry_point_process(options: list, outfile: str, tmp_path: Path) -> Non
         pytest.param(
             {
                 "config_file": Path("isoslam") / "default_config.yaml",
-                "bam_file": "tests/resources/bam/sorted_assigned/d0_no4sU_filtered_remapped_sorted.sorted.assigned.bam",
-                "gtf_file": "tests/resources/gtf/test_wash1.gtf",
-                "bed_file": "tests/resources/bed/test_coding_introns.bed",
-                "vcf_file": "tests/resources/vcf/d0.vcf.gz",
+                "bam_file": Path(
+                    "tests/resources/bam/sorted_assigned/d0_no4sU_filtered_remapped_sorted.sorted.assigned.bam"
+                ),
+                "gtf_file": Path("tests/resources/gtf/test_wash1.gtf"),
+                "bed_file": Path("tests/resources/bed/test_coding_introns.bed"),
+                "vcf_file": Path("tests/resources/vcf/d0.vcf.gz"),
             },
             id="no4sU",
         ),
         pytest.param(
             {
                 "config_file": Path("isoslam") / "default_config.yaml",
-                "bam_file": "tests/resources/bam/sorted_assigned/d0_0hr1_filtered_remapped_sorted.sorted.assigned.bam",
-                "gtf_file": "tests/resources/gtf/test_wash1.gtf",
-                "bed_file": "tests/resources/bed/test_coding_introns.bed",
-                "vcf_file": "tests/resources/vcf/d0.vcf.gz",
+                "bam_file": Path(
+                    "tests/resources/bam/sorted_assigned/d0_0hr1_filtered_remapped_sorted.sorted.assigned.bam"
+                ),
+                "gtf_file": Path("tests/resources/gtf/test_wash1.gtf"),
+                "bed_file": Path("tests/resources/bed/test_coding_introns.bed"),
+                "vcf_file": Path("tests/resources/vcf/d0.vcf.gz"),
             },
             id="0hr1",
         ),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,71 @@
+"""Test validation function."""
+
+from collections.abc import Callable
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+
+import pytest
+from schema import Or, Schema, SchemaError
+
+from isoslam import validation
+
+TEST_SCHEMA = Schema(
+    {
+        "a": Path,
+        "b": Or("aa", "bb", error="Invalid value in config, valid values are 'aa' or 'bb"),
+        "logical": bool,
+        "positive_integer": lambda n: 0 < n,
+        "int_or_float": Or(int, float, error="Invalid value in config should be type int or float"),
+    }
+)
+
+
+@pytest.mark.parametrize(
+    ("config", "expectation"),
+    [
+        pytest.param(
+            {"a": Path(), "b": "aa", "logical": True, "positive_integer": 4, "int_or_float": 10.0},
+            does_not_raise(),
+            id="valid configuration",
+        ),
+        pytest.param(
+            {"a": "path", "b": "aa", "logical": True, "positive_integer": 4, "int_or_float": 10.0},
+            pytest.raises(SchemaError),
+            id="invalid Path",
+        ),
+        pytest.param(
+            {"a": Path(), "b": 3, "logical": False, "positive_integer": 4, "int_or_float": 10.0},
+            pytest.raises(SchemaError),
+            id="invalid str",
+        ),
+        pytest.param(
+            {"a": Path(), "b": "bb", "logical": True, "positive_integer": -4, "int_or_float": 10.0},
+            pytest.raises(SchemaError),
+            id="negative integer",
+        ),
+        pytest.param(
+            {"a": Path(), "b": "aa", "logical": False, "positive_integer": 4, "int_or_float": "five"},
+            pytest.raises(SchemaError),
+            id="invalid int/float",
+        ),
+        pytest.param(
+            {"a": Path(), "b": "bb", "logical": "True", "positive_integer": 4, "int_or_float": "five"},
+            pytest.raises(SchemaError),
+            id="invalid boolean",
+        ),
+        pytest.param(
+            {"a": Path(), "b": "bb", "logical": 1, "positive_integer": 4, "int_or_float": 2},
+            pytest.raises(SchemaError),
+            id="boolean as int (1)",
+        ),
+        pytest.param(
+            {"a": Path(), "b": "aa", "logical": 0, "positive_integer": 4, "int_or_float": 4},
+            pytest.raises(SchemaError),
+            id="boolean as int (0)",
+        ),
+    ],
+)
+def test_validate_config(config: dict, expectation: Callable) -> None:
+    """Test various configurations."""
+    with expectation:
+        validation.validate_config(config, schema=TEST_SCHEMA, config_type="Test YAML")


### PR DESCRIPTION
Closes #73

Adds a module to validate the configuration _after_ loading and updating with any user specified command line
options. Its useful to check these early in processing and exit if things aren't right.

- Test is included.
- Instructions on adding configuration options and how to ensure they too are validated are included in the
  documentation.

~~One thing I'm unsure about and would appreciate input on @IanSudberry is the string forms that would be valid for the
chromosome field. I've treated as strings because of `X` and `Y` and the possibility the values are prefixed with
`chr#`.

- Is the possibility of the chromosome indicator being prefixed with `chr` correct or not? (its easy to remove them in
  this PR if that notation is never observed)
- Are the x/y chromosomes _always_ upper or lower case or could there be a mixture?~~

Scrub the above @IanSudbery I wasn't thinking clearly, this section refers to validating the schema that is passed to the Polars dataframe and only the types of those variables needs to be tested, not the actual values.