### PR TITLE
ci: Adds workflow to publish to PyPI; pre-commit gitleaks

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,38 @@
+name: Publish package to PyPi
+# See https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch: # Uncomment line if you also want to trigger action manually
+
+jobs:
+  build-release:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    name: Publish package to PyPi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Installing the package
+        run: |
+          pip3 install .
+          pip3 install .[pypi]
+      - name: Build package
+        run: |
+          pip3 install --upgrade setuptools
+          export DEB_PYTHON_INSTALL_LAYOUT=deb_system
+          python -m build --no-isolation
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,9 @@ cython_debug/
 # pytest-testmon
 .testmon*
 
+# PyPI
+.pypirc
+
 # Misc
 tmp/
 data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,11 @@ repos:
             "--exclude='^pipeline_slam_3UIs\\.py$'",
           ]
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks
+
   # - repo: https://codeberg.org/lig/todo-md.git
   #   rev: v2.0.1
   #   hooks:


### PR DESCRIPTION
As part of #171 this adds a workflow for publishing to PyPI. This is based on tagging commits with the pattern
`v*`. [PEP440](https://peps.python.org/pep-0440/) is the original specification for this, although as noted the current up-to-date specification can be found on the [Python Packaging Authority (PyPA) Specifications](https://packaging.python.org/en/latest/specifications/version-specifiers).

> The canonical public version identifiers MUST comply with the following scheme:
>
>     [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
>
> Public version identifiers MUST NOT include leading or trailing whitespace.
>
> Public version identifiers MUST be unique within a given distribution.
> ...
>
> Public version identifier are separated into up to five segments:
>
> - Epoch segment: N!
> - Release segment: N(.N)*
> - Pre-release segment: {a|b|rc}N
> - Post-release segment: .postN
> - Development release segment: .devN

Currently I would class IsoSLAM as pre-release and so we should start with `v0.0.1-a1` and increment `a#`.

As the process of making releases involves generating tokens which are to be stored in `.pypirc` (should manual release be made/required), I have added a [gitleaks pre-commit hook](https://github.com/gitleaks/gitleaks#pre-commit) that checks these have not been included in commits as well as the traditional method of adding them to `.gitignore`.