### PR TITLE
ci: Add test-pypi.yaml for testing releases

### DIFF
--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -1,0 +1,39 @@
+name: Publish package to PyPi
+# See https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+
+on:
+  push:
+    tags:
+      - v*-*
+  workflow_dispatch: # Uncomment line if you also want to trigger action manually
+
+jobs:
+  build-release:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    environment: testpypi
+    name: Publish package to PyPi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Installing the package
+        run: |
+          pip3 install .
+          pip3 install .[pypi]
+      - name: Build package
+        run: |
+          pip3 install --upgrade setuptools
+          export DEB_PYTHON_INSTALL_LAYOUT=deb_system
+          python -m build --no-isolation
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
As per instructions on the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) this adds a `.github/workflows/test-pypi.yaml` workflow to test releases.

This is triggered by commits of the form `v*-*` where `-` is a [pre-release separator](https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-release-separators).